### PR TITLE
fix: 주신체/세부신체 연관관계 및 기능 수정

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SubBodyPartService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SubBodyPartService.java
@@ -25,4 +25,10 @@ public class SubBodyPartService {
                 .map(SubBodyPartResponseDTO::fromEntity)
                 .collect(Collectors.toList());
     }
+
+    // MainBodyPart에 속하는 SubBodyPart 모두 조회
+    @Transactional
+    public List<SubBodyPart> getSubBodyPartsByMainBodyPartBodies(List<String> bodies) {
+        return subBodyPartRepository.findAllByMainBodyPartBodies(bodies);
+    }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedSBP.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedSBP.java
@@ -33,10 +33,11 @@ public class SelectedSBP extends BaseEntity {
     @Column(name = "sbp_id", nullable = false)
     private List<Long> sbpIds;
 
-    @Column(name = "mbp_id", nullable = false)
-    private Long mbpId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_mbp_id")
+    private SelectedMBP selectedMBP;
 
-    public void updateSelectedSBP(SelectedSBPRequestDTO requestDTO, List<Long> sbpIds) {
+    public void updateSelectedSBP(SelectedSBPRequestDTO requestDTO, List<Long> sbpIds, SelectedMBP selectedMBP) {
         if (requestDTO.getBody() == null) {
             this.body = new ArrayList<>();
             this.sbpIds = new ArrayList<>();
@@ -44,5 +45,6 @@ public class SelectedSBP extends BaseEntity {
             this.body = new ArrayList<>(requestDTO.getBody());
             this.sbpIds = new ArrayList<>(sbpIds);
         }
+        this.selectedMBP = selectedMBP;
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/MainBodyPartRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/MainBodyPartRepository.java
@@ -3,10 +3,10 @@ package com.mediko.mediko_server.domain.openai.domain.repository;
 import com.mediko.mediko_server.domain.openai.domain.MainBodyPart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface MainBodyPartRepository extends JpaRepository<MainBodyPart, Long> {
-    // 주어진 body와 일치하는 MainBodyPart 조히
-    Optional<MainBodyPart> findByBody(String body);
+    List<MainBodyPart> findByBodyIn(List<String> bodies);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedMBPRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedMBPRepository.java
@@ -1,16 +1,12 @@
 package com.mediko.mediko_server.domain.openai.domain.repository;
 
+import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.domain.SelectedMBP;
-import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 
 public interface SelectedMBPRepository extends JpaRepository<SelectedMBP, Long> {
-    // 최신 SelectedMBP를 조회하는 쿼리
-    @Query(value = "SELECT * FROM selected_mbp WHERE member_id = :memberId ORDER BY created_at DESC LIMIT 1", nativeQuery = true)
-    Optional<SelectedMBP> findLatestByMemberId(@Param("memberId") Long memberId);
+    Optional<SelectedMBP> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSBPRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSBPRepository.java
@@ -1,16 +1,17 @@
 package com.mediko.mediko_server.domain.openai.domain.repository;
 
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.openai.domain.SelectedMBP;
 import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SelectedSBPRepository extends JpaRepository<SelectedSBP, Long> {
-    // 최신 SelectedSBP를 조회하는 쿼리
-    @Query(value = "SELECT * FROM selected_sbp WHERE member_id = :memberId ORDER BY created_at DESC LIMIT 1", nativeQuery = true)
-    Optional<SelectedSBP> findLatestByMemberId(@Param("memberId") Long memberId);
+    Optional<SelectedSBP> findByIdAndMember(Long selectedSbpId, Member member);
+
+    List<SelectedSBP> findBySelectedMBPAndMember(SelectedMBP selectedMBP, Member member);
 }
 
 

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
@@ -14,7 +14,7 @@ public class SelectedMBPResponseDTO {
 
     private List<Long> mbpIds;
 
-    private Long selectedMbpId;
+    private Long selectedMBPId;
 
     private Long memberId;
 

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
@@ -14,9 +14,9 @@ public class SelectedSBPResponseDTO {
 
     private List<Long> sbpIds;
 
-    private Long mbpId;
+    private Long selectedSBPId;
 
-    private Long selectedSbpId;
+    private Long selectedMBPId;
 
     private Long memberId;
 
@@ -24,8 +24,8 @@ public class SelectedSBPResponseDTO {
         return new SelectedSBPResponseDTO(
                 selectedSBP.getBody(),
                 selectedSBP.getSbpIds(),
-                selectedSBP.getMbpId(),
                 selectedSBP.getId(),
+                selectedSBP.getSelectedMBP().getId(),
                 selectedSBP.getMember().getId()
         );
     }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/MainBodyPartController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/MainBodyPartController.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class MainBodyPartController {
     private final MainBodyPartService mainBodyPartService;
 
-    // 모든 MainBodyPart 조회
+    // 모든 주신체 부분 조회
     @GetMapping()
     public ResponseEntity<List<MainBodyPartResponseDTO>> findAll() {
         List<MainBodyPartResponseDTO> mainBodyParts = mainBodyPartService.findAll();

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedMBPController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedMBPController.java
@@ -29,25 +29,29 @@ public class SelectedMBPController {
         return ResponseEntity.ok(responseDTO);
     }
 
-    // 최신 주신체 부분 조회
-    @GetMapping
+    // 특정 selectedMBP 조회
+    @GetMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedMBPResponseDTO> getSelectedMBP(
+            @PathVariable("selectedMBPId") Long selectedMBPId,
             @AuthenticationPrincipal CustomUserDetails userDetail) {
 
         Member member = userDetail.getMember();
-        SelectedMBPResponseDTO responseDTO = selectedMBPService.getLatestSelectedSBP(member);
+        SelectedMBPResponseDTO responseDTO = selectedMBPService.getSelectedMBP(selectedMBPId, member);
         return ResponseEntity.ok(responseDTO);
     }
 
-    // 최신 주신체 부분 수정
-    @PutMapping
+
+    // 특정 주신체 부분 수정
+    @PutMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedMBPResponseDTO> updateSelectedMBP(
+            @PathVariable("selectedMBPId") Long selectedMBPId,
             @RequestBody SelectedMBPRequestDTO requestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetail) {
 
         Member member = userDetail.getMember();
-        SelectedMBPResponseDTO responseDTO = selectedMBPService.updateLatestSelectedSBP(requestDTO, member);
+        SelectedMBPResponseDTO responseDTO = selectedMBPService.updateSelectedMBP(selectedMBPId, requestDTO, member);
         return ResponseEntity.ok(responseDTO);
     }
+
 
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSBPController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSBPController.java
@@ -3,10 +3,8 @@ package com.mediko.mediko_server.domain.openai.presentation;
 import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.application.SelectedSBPService;
-import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
 import com.mediko.mediko_server.domain.openai.dto.request.SelectedSBPRequestDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.SelectedSBPResponseDTO;
-import com.mediko.mediko_server.domain.openai.dto.response.SubBodyPartResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,8 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -24,48 +20,40 @@ import java.util.stream.Collectors;
 public class SelectedSBPController {
     private final SelectedSBPService selectedSBPService;
 
-    //선택된 주신체 부분에 포함된 모든 세부신체 부분 조회
-    @PostMapping
-    public ResponseEntity<List<SubBodyPartResponseDTO>> getSubBodyPartsByBodies(
-            @RequestBody SelectedSBPRequestDTO requestBody
-    ) {
-        List<SubBodyPart> subBodyParts = selectedSBPService.getSubBodyPartsByMainBodyPartBodies(requestBody.getBody());
-        List<SubBodyPartResponseDTO> response = subBodyParts.stream()
-                .map(SubBodyPartResponseDTO::fromEntity)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(response);
-    }
-
     //선택된 세부신체 부분 저장
-    @PostMapping("/save")
+    @PostMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedSBPResponseDTO> saveSelectedSBP(
-            @AuthenticationPrincipal CustomUserDetails userDetail,
-            @RequestBody SelectedSBPRequestDTO requestDTO
+            @PathVariable("selectedMBPId") Long selectedMBPId,
+            @RequestBody SelectedSBPRequestDTO requestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetail
     ) {
         Member member = userDetail.getMember();
-        SelectedSBPResponseDTO responseDTO = selectedSBPService.saveSelectedSBP(member, requestDTO);
+        SelectedSBPResponseDTO responseDTO = selectedSBPService.saveSelectedSBP(member, requestDTO, selectedMBPId);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
     }
 
-    // 최신 세부신체 부분 조회
-    @GetMapping
-    public ResponseEntity<SelectedSBPResponseDTO> getLatestSelectedSBP(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+
+    // 특정 세부신체 부분 조회
+    @GetMapping("/{selectedSBPId}")
+    public ResponseEntity<SelectedSBPResponseDTO> getSelectedSBP(
+            @PathVariable("selectedSBPId") Long selectedSBPId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
         Member member = userDetails.getMember();
-        SelectedSBPResponseDTO responseDTO = selectedSBPService.getLatestSelectedSBP(member);
+        SelectedSBPResponseDTO responseDTO = selectedSBPService.getSelectedSBP(selectedSBPId, member);
         return ResponseEntity.ok(responseDTO);
     }
 
-
-    //최신 세부신체 부분 수정
-    @PutMapping
+    // 특정 세부신체 부분 수정
+    @PutMapping("/{selectedSBPId}")
     public ResponseEntity<SelectedSBPResponseDTO> updateSelectedSBP(
+            @PathVariable("selectedSBPId") Long selectedSBPId,
             @RequestBody SelectedSBPRequestDTO requestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         Member member = userDetails.getMember();
-        SelectedSBPResponseDTO responseDTO = selectedSBPService.updateLatestSelectedSBP(member, requestDTO);
+        SelectedSBPResponseDTO responseDTO = selectedSBPService.updateSelectedSBP(selectedSBPId, member, requestDTO);
         return ResponseEntity.ok(responseDTO);
     }
+
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
@@ -1,15 +1,16 @@
 package com.mediko.mediko_server.domain.openai.presentation;
 
 import com.mediko.mediko_server.domain.openai.application.SubBodyPartService;
+import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
+import com.mediko.mediko_server.domain.openai.dto.request.SelectedSBPRequestDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.SubBodyPartResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -18,10 +19,22 @@ import java.util.List;
 public class SubBodyPartController {
     private final SubBodyPartService subBodyPartService;
 
-    // 모든 SubBodyPart 조회
+    // 모든 세부신체 부분 조회
     @GetMapping()
     public ResponseEntity<List<SubBodyPartResponseDTO>> findAll() {
         List<SubBodyPartResponseDTO> subBodyParts = subBodyPartService.findAll();
         return ResponseEntity.ok(subBodyParts);
+    }
+
+    //선택된 주신체 부분에 포함된 모든 세부신체 부분 조회
+    @PostMapping
+    public ResponseEntity<List<SubBodyPartResponseDTO>> getSubBodyPartsByBodies(
+            @RequestBody SelectedSBPRequestDTO requestBody
+    ) {
+        List<SubBodyPart> subBodyParts = subBodyPartService.getSubBodyPartsByMainBodyPartBodies(requestBody.getBody());
+        List<SubBodyPartResponseDTO> response = subBodyParts.stream()
+                .map(SubBodyPartResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #10 

### 🔑 주요 변경사항
- mainBodyPart에 포함되는 모든 subBodyPart를 조회하는 메서드를 subBodyPartServcie로 이동
- selectedSBP에서 selectedMBP를 manyToOne으로 참조
- selectedMBP를 수정하면 연관된 selectedSBP를 자동으로 삭제
- 최신 selectedMBP와 SBP를 조회/수정 하는 것에서 id를 @PathVariable로 넣어서 조회/수정
- selectedMbp와 selectedSbp라는 컬럼명을 모두 selectedMBP와 selectedSBP로 통일

