### PR TITLE
fix: Member와 BasicInfo/HealthInfo 연관관계 수정

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
@@ -24,63 +24,45 @@ public class BasicInfoService {
     private final MemberRepository memberRepository;
     private final BasicInfoRepository basicInfoRepository;
 
-    //BasicInfo 저장
+    // BasicInfo 저장
     @Transactional
-    public BasicInfoResponseDTO saveBasicInfo(String loginId, BasicInfoRequestDTO basicInfoRequestDTO) {
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
+    public BasicInfoResponseDTO saveBasicInfo(Member member, BasicInfoRequestDTO basicInfoRequestDTO) {
 
-        if (member.getBasicInfo() != null) {
+        if (basicInfoRepository.existsByMember(member)) {
             throw new BadRequestException(DATA_ALREADY_EXIST, "사용자의 기본정보가 이미 저장되었습니다.");
         }
 
-        BasicInfo basicInfo = basicInfoRequestDTO.toEntity();
+        BasicInfo basicInfo = basicInfoRequestDTO.toEntity().toBuilder()
+                .member(member)
+                .build();
+
         basicInfo.validateBasicInfoFields();
 
-        basicInfoRepository.save(basicInfo);
+        BasicInfo savedBasicInfo = basicInfoRepository.save(basicInfo);
 
-        // member = member.toBuilder()
-        //        .basicInfo(basicInfo)
-        //        .build();
-        member.setBasicInfo(basicInfo); //toBuilder로 수정할 시 객체가 새로 생성돼서 데이터무결성 오류 발생(login_id  중복)
-        member.changeRole(UserStatus.ROLE_USER); //role 변경
-
+        member.changeRole(UserStatus.ROLE_USER);
         memberRepository.save(member);
 
-        return BasicInfoResponseDTO.fromEntity(basicInfo);
+        return BasicInfoResponseDTO.fromEntity(savedBasicInfo);
     }
 
-    //BasicInfo 조회
-    public BasicInfoResponseDTO getBasicInfo(String loginId) {
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
-
-        BasicInfo basicInfo = member.getBasicInfo();
-        if (basicInfo == null) {
-            throw new BadRequestException(DATA_NOT_EXIST, "사용자의 기본 정보가 설정되지 않았습니다.");
-        }
+    // BasicInfo 조회
+    public BasicInfoResponseDTO getBasicInfo(Member member) {
+        BasicInfo basicInfo = basicInfoRepository.findByMember(member)
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "사용자의 기본 정보가 설정되지 않았습니다."));
 
         return BasicInfoResponseDTO.fromEntity(basicInfo);
     }
 
-    //BasicInfo 수정
+    // BasicInfo 수정
     @Transactional
-    public BasicInfoResponseDTO updateBasicInfo(String loginId, BasicInfoRequestDTO basicInfoRequestDTO) {
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
+    public BasicInfoResponseDTO updateBasicInfo(Member member, BasicInfoRequestDTO basicInfoRequestDTO) {
+        BasicInfo existingBasicInfo = basicInfoRepository.findByMember(member)
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "사용자의 기본 정보가 설정되지 않았습니다."));
 
-        if (member.getBasicInfo() == null) {
-            throw new BadRequestException(DATA_NOT_EXIST, "사용자의 기본 정보가 설정되지 않았습니다.");
-        }
-
-        BasicInfo existingBasicInfo = member.getBasicInfo();
         existingBasicInfo.updateBasicInfo(basicInfoRequestDTO);
-
         basicInfoRepository.save(existingBasicInfo);
-
-        memberRepository.save(member);
 
         return BasicInfoResponseDTO.fromEntity(existingBasicInfo);
     }
-
 }

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/BasicInfo.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/BasicInfo.java
@@ -5,9 +5,7 @@ import com.mediko.mediko_server.domain.member.domain.infoType.Language;
 import com.mediko.mediko_server.domain.member.dto.request.BasicInfoRequestDTO;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +40,10 @@ public class BasicInfo extends BaseEntity {
 
     @Column(name = "weight", nullable = false)
     private Integer weight;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     public void validateBasicInfoFields() {
         if (this.language == null ||

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/HealthInfo.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/HealthInfo.java
@@ -4,9 +4,7 @@ import com.mediko.mediko_server.domain.member.dto.request.BasicInfoRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.request.HealthInfoRequestDTO;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +31,10 @@ public class HealthInfo extends BaseEntity {
 
     @Column(name = "allergy")
     private String allergy;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     public void validateHealthInfoFields() {
         if (this.pastHistory == null || this.pastHistory.isBlank() ||

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/Member.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/Member.java
@@ -49,13 +49,6 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(name = "role", nullable = false)
     private UserStatus role;
 
-    @OneToOne
-    @JoinColumn(name = "basic_info_id")
-    private BasicInfo basicInfo;
-
-    @OneToOne
-    @JoinColumn(name = "health_info_id")
-    private HealthInfo healthInfo;
 
     /**
      * UserDetails 인터페이스 메서드

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/repository/BasicInfoRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/repository/BasicInfoRepository.java
@@ -3,9 +3,14 @@ package com.mediko.mediko_server.domain.member.domain.repository;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BasicInfoRepository extends JpaRepository<BasicInfo, Long> {
 
+    // Member를 기반으로 BasicInfo 조회
+    Optional<BasicInfo> findByMember(Member member);
+
+    // Member를 기반으로 BasicInfo 존재 여부 확인
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/member/domain/repository/HealthInfoRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/domain/repository/HealthInfoRepository.java
@@ -4,5 +4,9 @@ import com.mediko.mediko_server.domain.member.domain.HealthInfo;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface HealthInfoRepository extends JpaRepository<HealthInfo, Long> {
+    Optional<HealthInfo> findByMember(Member member);
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/BasicInfoController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/BasicInfoController.java
@@ -2,15 +2,14 @@ package com.mediko.mediko_server.domain.member.presentation;
 
 import com.mediko.mediko_server.domain.member.application.BasicInfoService;
 import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
+import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.member.dto.request.BasicInfoRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.response.BasicInfoResponseDTO;
-import com.mediko.mediko_server.domain.member.dto.response.HealthInfoResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpStatus.CREATED;
@@ -26,10 +25,10 @@ public class BasicInfoController {
     // BasicInfo 저장
     @PostMapping
     public ResponseEntity<BasicInfoResponseDTO> saveBasicInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody BasicInfoRequestDTO basicInfoRequestDTO) {
-        String loginId = customUserDetails.getUsername();
-        BasicInfoResponseDTO savedBasicInfo = basicInfoService.saveBasicInfo(loginId, basicInfoRequestDTO);
+        Member member = userDetails.getMember();
+        BasicInfoResponseDTO savedBasicInfo = basicInfoService.saveBasicInfo(member, basicInfoRequestDTO);
         return ResponseEntity.status(CREATED).body(savedBasicInfo);
     }
 
@@ -37,9 +36,9 @@ public class BasicInfoController {
     @GetMapping
     @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<BasicInfoResponseDTO> getBasicInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        String loginId = customUserDetails.getUsername();
-        BasicInfoResponseDTO basicInfoResponseDTO = basicInfoService.getBasicInfo(loginId);
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = userDetails.getMember();
+        BasicInfoResponseDTO basicInfoResponseDTO = basicInfoService.getBasicInfo(member);
         return ResponseEntity.ok(basicInfoResponseDTO);
     }
 
@@ -49,8 +48,8 @@ public class BasicInfoController {
     public ResponseEntity<BasicInfoResponseDTO> updateBasicInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody BasicInfoRequestDTO basicInfoRequestDTO) {
-        String loginId = userDetails.getUsername();
-        BasicInfoResponseDTO updatedBasicInfo = basicInfoService.updateBasicInfo(loginId, basicInfoRequestDTO);
+        Member member = userDetails.getMember();
+        BasicInfoResponseDTO updatedBasicInfo = basicInfoService.updateBasicInfo(member, basicInfoRequestDTO);
         return ResponseEntity.ok(updatedBasicInfo);
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/HealthInfoController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/HealthInfoController.java
@@ -2,15 +2,14 @@ package com.mediko.mediko_server.domain.member.presentation;
 
 import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
 import com.mediko.mediko_server.domain.member.application.HealthInfoService;
+import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.member.dto.request.HealthInfoRequestDTO;
-import com.mediko.mediko_server.domain.member.dto.response.BasicInfoResponseDTO;
 import com.mediko.mediko_server.domain.member.dto.response.HealthInfoResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpStatus.CREATED;
@@ -26,10 +25,10 @@ public class HealthInfoController {
     // HealthInfo 저장
     @PostMapping
     public ResponseEntity<HealthInfoResponseDTO> saveHealthInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody HealthInfoRequestDTO healthInfoRequestDTO) {
-        String loginId = customUserDetails.getUsername();
-        HealthInfoResponseDTO savedHealthInfo = healthInfoService.saveHealthInfo(loginId, healthInfoRequestDTO);
+        Member member = userDetails.getMember();
+        HealthInfoResponseDTO savedHealthInfo = healthInfoService.saveHealthInfo(member, healthInfoRequestDTO);
         return ResponseEntity.status(CREATED).body(savedHealthInfo);
     }
 
@@ -37,9 +36,9 @@ public class HealthInfoController {
     @GetMapping
     @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<HealthInfoResponseDTO> getHealthInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        String loginId = customUserDetails.getUsername();
-        HealthInfoResponseDTO healthInfoResponseDTO = healthInfoService.getHealthInfo(loginId);
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = userDetails.getMember();
+        HealthInfoResponseDTO healthInfoResponseDTO = healthInfoService.getHealthInfo(member);
         return ResponseEntity.ok(healthInfoResponseDTO);
     }
 
@@ -47,10 +46,10 @@ public class HealthInfoController {
     @PatchMapping
     @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<HealthInfoResponseDTO> updateHealthInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody HealthInfoRequestDTO healthInfoRequestDTO) {
-        String loginId = customUserDetails.getUsername();
-        HealthInfoResponseDTO updatedHealthInfo = healthInfoService.updateHealthInfo(loginId, healthInfoRequestDTO);
+        Member member = userDetails.getMember();
+        HealthInfoResponseDTO updatedHealthInfo = healthInfoService.updateHealthInfo(member, healthInfoRequestDTO);
         return ResponseEntity.ok(updatedHealthInfo);
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #14 

### 🔑 주요 변경사항
- 회원과 기본정보 간 OneToOne 관계의 주인을 기본정보로 변경 필요
- 회원과 건강정보 간 OneToOne 관계의 주인을 건강정보로 변경 필요
- service와 controller의 파라미터를 loginId에서 member로 변경
