### PR TITLE
fix: request의 주소를 lat과 lon으로 받는 것으로 통일, flask 연결 수정

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/ErService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/ErService.java
@@ -5,10 +5,13 @@ import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.repository.BasicInfoRepository;
 import com.mediko.mediko_server.domain.member.domain.repository.LocationRepository;
+import com.mediko.mediko_server.domain.recommend.application.converter.ErConverter;
+import com.mediko.mediko_server.domain.recommend.application.factory.ErRequestFactory;
 import com.mediko.mediko_server.domain.recommend.domain.Er;
 import com.mediko.mediko_server.domain.recommend.domain.repository.ErRepository;
 import com.mediko.mediko_server.domain.recommend.dto.request.ErRequestDTO;
 import com.mediko.mediko_server.domain.recommend.dto.response.ErResponseDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.PharmacyResponseDTO;
 import com.mediko.mediko_server.global.flask.FlaskCommunicationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,9 +27,10 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ErService {
     private final BasicInfoRepository basicInfoRepository;
-    private final LocationRepository locationRepository;
     private final ErRepository erRepository;
     private final FlaskCommunicationService flaskCommunicationService;
+    private final ErRequestFactory erRequestFactory;
+    private final ErConverter erConverter;
 
     @Transactional
     public List<ErResponseDTO> recommendEr(ErRequestDTO requestDTO) {
@@ -34,65 +38,28 @@ public class ErService {
         BasicInfo basicInfo = basicInfoRepository.findById(requestDTO.getBasicInfoId())
                 .orElseThrow(() -> new RuntimeException("BasicInfo not found"));
 
-        // 2. Location 조회
-        Location location = locationRepository.findById(requestDTO.getLocationId())
-                .orElseThrow(() -> new RuntimeException("Location not found"));
+        // 2. Flask 서버에 보낼 요청 데이터 생성
+        Map<String, Object> flaskRequestData = erRequestFactory.createFlaskRequest(
+                basicInfo, requestDTO.getUserLatitude(), requestDTO.getUserLongitude()
+        );
 
-        // 3. Flask 서버에 보낼 요청 데이터 생성
-        // Map으로 받아서 전달
-        Map<String, Object> requestData = buildRequestData(basicInfo, location);
+        // 3. Flask 서버로 요청 보내고 응답 받기
+        List<ErResponseDTO> flaskResponses = flaskCommunicationService
+                .getErRecommendation(flaskRequestData);
 
-        // 4. Flask 서버로 요청 보내고 응답 받기
-        List<ErResponseDTO> flaskResponses = flaskCommunicationService.getErRecommendation(requestData);
-
-        // 응답 유효성 검사
         if (flaskResponses == null || flaskResponses.isEmpty()) {
-            throw new RuntimeException("No hospital recommendations received");
+            throw new RuntimeException("No ER recommendations received");
         }
 
-        // 5. 엔티티 변환 및 저장
-        return flaskResponses.stream()
-                .map(flaskResponse -> {
-                    try {
-                        Er baseER = requestDTO.toEntity(basicInfo, location);
-                        Er er = baseER.toBuilder()
-                                .name(flaskResponse.getName())
-                                .address(flaskResponse.getAddress())
-                                .tel(flaskResponse.getTel())
-                                .hvamyn(flaskResponse.getHvamyn())
-                                .isTrauma(flaskResponse.getIsTrauma())
-                                .travelKm(flaskResponse.getTravelKm())
-                                .travelH(flaskResponse.getTravelH())
-                                .travelS(flaskResponse.getTravelS())
-                                .travelM(flaskResponse.getTravelM())
-                                .member(basicInfo.getMember())
-                                .build();
-
-                        Er savedER = erRepository.save(er);
-                        return ErResponseDTO.fromEntity(savedER);
-                    } catch (Exception e) {
-                        throw new RuntimeException("병원 데이터 처리 중 오류 발생", e);
-                    }
-                })
+        // 4. Flask 응답을 엔티티로 변환 후 저장
+        List<Er> savedErs = flaskResponses.stream()
+                .map(response -> erConverter.toEntity(response, requestDTO, basicInfo))
+                .map(erRepository::save)
                 .collect(Collectors.toList());
-    }
 
-    private Map<String, Object> buildRequestData(BasicInfo basicInfo, Location location) {
-
-        Map<String, Object> basicInfoMap = new HashMap<>();
-        basicInfoMap.put("language", basicInfo.getLanguage().toString());
-        basicInfoMap.put("number", basicInfo.getNumber());
-        basicInfoMap.put("address", basicInfo.getAddress());
-        basicInfoMap.put("gender", basicInfo.getGender().toString());
-        basicInfoMap.put("age", basicInfo.getAge());
-        basicInfoMap.put("height", basicInfo.getHeight());
-        basicInfoMap.put("weight", basicInfo.getWeight());
-
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("basic_info", basicInfoMap);
-        requestMap.put("lat", location.getLat());
-        requestMap.put("lon", location.getLon());
-
-        return requestMap;  // String으로 변환하지 않고 Map 그대로 반환
+        // 5. 저장된 엔티티를 DTO로 변환하여 반환
+        return savedErs.stream()
+                .map(ErResponseDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/HospitalService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/HospitalService.java
@@ -1,30 +1,35 @@
 package com.mediko.mediko_server.domain.recommend.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.repository.BasicInfoRepository;
 import com.mediko.mediko_server.domain.member.domain.repository.HealthInfoRepository;
-import com.mediko.mediko_server.domain.member.domain.repository.LocationRepository;
+import com.mediko.mediko_server.domain.recommend.application.factory.HospitalRequestFactory;
+import com.mediko.mediko_server.domain.recommend.application.converter.HospitalConverter;
 import com.mediko.mediko_server.domain.recommend.domain.Hospital;
 import com.mediko.mediko_server.domain.recommend.domain.repository.HospitalRepository;
 import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
 import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
 import com.mediko.mediko_server.domain.report.domain.Report;
 import com.mediko.mediko_server.domain.report.domain.repository.ReportRepository;
+import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
+import com.mediko.mediko_server.global.exception.exceptionType.ServiceUnavailableException;
 import com.mediko.mediko_server.global.flask.FlaskCommunicationService;
-import com.mediko.mediko_server.global.flask.FlaskUrls;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.mediko.mediko_server.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -33,127 +38,115 @@ import java.util.stream.Collectors;
 public class HospitalService {
     private final BasicInfoRepository basicInfoRepository;
     private final HealthInfoRepository healthInfoRepository;
-    private final HospitalRepository hospitalRepository;
     private final ReportRepository reportRepository;
-    private final LocationRepository locationRepository;
+    private final HospitalRequestFactory hospitalRequestFactory;
     private final FlaskCommunicationService flaskCommunicationService;
+    private final HospitalConverter hospitalConverter;
+    private final HospitalRepository hospitalRepository;
 
 
     @Transactional
     public List<HospitalResponseDTO> recommendHospital(HospitalRequestDTO requestDTO) {
         // 1. BasicInfo 및 HealthInfo 조회
         BasicInfo basicInfo = basicInfoRepository.findById(requestDTO.getBasicInfoId())
-                .orElseThrow(() -> new RuntimeException("BasicInfo not found"));
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "사용자의 기본정보가 존재하지 않습니다."));
 
         HealthInfo healthInfo = healthInfoRepository.findById(requestDTO.getHealthInfoId())
-                .orElseThrow(() -> new RuntimeException("HealthInfo not found"));
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "사용자의 건강정보가 존재하지 않습니다."));
 
-        Location location = locationRepository.findById(requestDTO.getLocationId())
-                .orElseThrow(() -> new RuntimeException("Location not found"));
+        // 2. 사용자 위치 처리 (latitude, longitude)
+        if (requestDTO.getUserLatitude() == null || requestDTO.getUserLongitude() == null) {
+            throw new BadRequestException(INVALID_PARAMETER, "사용자의 위도와 경도 정보는 필수입니다.");
+        }
+        Double userLatitude = requestDTO.getUserLatitude();
+        Double userLongitude = requestDTO.getUserLongitude();
 
-        // 2. department와 suspectedDisease 설정
+        // 3. department와 suspectedDisease 설정
         String department;
         String suspectedDisease;
 
         if (requestDTO.isReport()) {
+            // Report 기반 처리 로직
+            if (requestDTO.getReportId() == null) {
+                throw new BadRequestException(INVALID_PARAMETER, "Report 정보를 사용할 경우, reportId는 필수입니다.");
+            }
+
+            if (requestDTO.getUserDepartment() != null ||
+                    (requestDTO.getSuspectedDisease() != null && !requestDTO.getSuspectedDisease().isEmpty())) {
+                throw new BadRequestException(INVALID_PARAMETER, "Report 정보를 사용할 경우, 진료과와 예상질병은 사용자가 입력할 수 없습니다.");
+            }
+
             Report report = reportRepository.findById(requestDTO.getReportId())
-                    .orElseThrow(() -> new RuntimeException("Report not found"));
+                    .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "Report를 찾을 수 없습니다."));
 
-            department = Optional.ofNullable(report.getRecommendedDepartment().get("name"))
+            department = Optional.ofNullable(report.getRecommendedDepartment().get("korean"))
                     .map(Object::toString)
-                    .orElseThrow(() -> new RuntimeException("Department name not found"));
+                    .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "Report에서 추천된 진료과를 찾을 수 없습니다."));
 
-            suspectedDisease = report.getPossibleConditions().stream()
-                    .flatMap(map -> map.values().stream())
-                    .map(Object::toString)
-                    .collect(Collectors.joining(","));
+            suspectedDisease = Optional.ofNullable(report.getPossibleConditions())
+                    .filter(conditions -> !conditions.isEmpty())
+                    .map(conditions -> {
+                        Map<String, String> firstCondition = conditions.get(0);  // String으로 받고
+                        log.info("First Condition: {}", firstCondition);
+
+                        Object nameValue = firstCondition.get("name");  // Object로 받아서
+                        log.info("Name value: {}", nameValue);
+
+                        @SuppressWarnings("unchecked")
+                        List<List<String>> nameList = (List<List<String>>) nameValue;  // 캐스팅
+                        return String.join(",", nameList.get(0));
+                    })
+                    .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "Report에서 예상 병명을 찾을 수 없습니다."));
         } else {
-            department = requestDTO.getDepartment();
+            // 사용자 입력 기반 처리 로직
+            if (requestDTO.getUserDepartment() == null || requestDTO.getSuspectedDisease() == null ||
+                    requestDTO.getSuspectedDisease().isEmpty()) {
+                throw new BadRequestException(INVALID_PARAMETER, "진료과와 예상질병은 필수입니다.");
+            }
+            department = requestDTO.getUserDepartment();
             suspectedDisease = String.join(",", requestDTO.getSuspectedDisease());
         }
 
-        // 3. Flask 서버에 보낼 요청 데이터 생성
-        Map<String, Object> requestData = buildRequestData(
-                basicInfo, healthInfo, location, department, suspectedDisease,
-                requestDTO.isSecondary_hospital(), requestDTO.isTertiary_hospital()
+        // 4. Flask 서버에 보낼 요청 데이터 생성
+        Map<String, Object> flaskRequestData = hospitalRequestFactory.createFlaskRequest(
+                basicInfo, healthInfo, userLatitude, userLongitude,
+                department, suspectedDisease, requestDTO.isSecondaryHospital(), requestDTO.isTertiaryHospital()
         );
 
-        // 4. Flask 서버로 요청 보내고 전체 응답 받기
-        List<HospitalResponseDTO> flaskResponses = flaskCommunicationService.getHospitalRecommendation(requestData);
+        // 5. Flask 서버로 요청 보내고 응답 받기
+        List<HospitalResponseDTO> flaskResponses = flaskCommunicationService
+                .getHospitalRecommendation(flaskRequestData);
 
         if (flaskResponses == null || flaskResponses.isEmpty()) {
-            throw new RuntimeException("No hospital recommendations received");
+            throw new ServiceUnavailableException(DATA_UNAVAILABLE, "병원 추천 정보를 받지 못했습니다.");
         }
 
-        // 5. 각 추천 병원에 대해 Hospital 엔티티 생성 및 저장
-        return flaskResponses.stream()
-                .map(flaskResponse -> {
-                    Hospital baseHospital = requestDTO.toEntity(
-                            basicInfo,
-                            healthInfo,
-                            department,
-                            suspectedDisease,
-                            location
-                    );
-                    Hospital hospital = baseHospital.toBuilder()
-                            .hpId(flaskResponse.getHpId())
-                            .name(flaskResponse.getName())
-                            .address(flaskResponse.getAddress())
-                            .telephone(flaskResponse.getTelephone())
-                            .latitude(flaskResponse.getLatitude())
-                            .longitude(flaskResponse.getLongitude())
-                            .esDistanceInKm(flaskResponse.getEsDistanceInKm())
-                            .sidocdnm(flaskResponse.getSidocdnm())
-                            .sggucdnm(flaskResponse.getSggucdnm())
-                            .emdongnm(flaskResponse.getEmdongnm())
-                            .clcdnm(flaskResponse.getClcdnm())
-                            .url(flaskResponse.getUrl())
-                            .member(basicInfo.getMember())
-                            .sortScore(flaskResponse.getSortScore())
-                            .departmentMatch(flaskResponse.getDepartmentMatch())
-                            .latLon(flaskResponse.getLatLon())
-                            .similarity(flaskResponse.getSimilarity())
-                            .travelKm(flaskResponse.getTravelKm())
-                            .travelH(flaskResponse.getTravelH())
-                            .travelM(flaskResponse.getTravelM())
-                            .travelS(flaskResponse.getTravelS())
-                            .build();
+        // 6. 응답 결과를 DB에 저장
+        Report report = requestDTO.isReport() ?
+                reportRepository.findById(requestDTO.getReportId()).orElse(null) : null;
 
-                    Hospital savedHospital = hospitalRepository.save(hospital);
-                    return HospitalResponseDTO.fromEntity(savedHospital);
-                })
+        for (HospitalResponseDTO response : flaskResponses) {
+            Hospital hospital = hospitalConverter.toEntity(
+                    response, requestDTO, department, suspectedDisease,
+                    basicInfo, healthInfo, report
+            );
+            hospitalRepository.save(hospital);
+        }
+
+        // 7. Flask 응답을 엔티티로 변환 후 저장
+        List<Hospital> savedHospitals = flaskResponses.stream()
+                .map(response -> hospitalConverter.toEntity(
+                        response, requestDTO, department, suspectedDisease,
+                        basicInfo, healthInfo, report
+                ))
+                .map(hospitalRepository::save)
+                .collect(Collectors.toList());
+
+        // 8. 저장된 엔티티를 DTO로 변환하여 반환
+        return savedHospitals.stream()
+                .map(HospitalResponseDTO::fromEntity)
                 .collect(Collectors.toList());
     }
 
-
-    private Map<String, Object> buildRequestData(BasicInfo basicInfo, HealthInfo healthInfo, Location location,
-                                                 String department, String suspectedDisease,
-                                                 boolean secondaryHospital, boolean tertiaryHospital) {
-        Map<String, Object> basicInfoMap = new HashMap<>();
-        basicInfoMap.put("language", basicInfo.getLanguage().toString());
-        basicInfoMap.put("number", basicInfo.getNumber());
-        basicInfoMap.put("address", basicInfo.getAddress());
-        basicInfoMap.put("gender", basicInfo.getGender().toString());
-        basicInfoMap.put("age", basicInfo.getAge());
-        basicInfoMap.put("height", basicInfo.getHeight());
-        basicInfoMap.put("weight", basicInfo.getWeight());
-
-        Map<String, Object> healthInfoMap = new HashMap<>();
-        healthInfoMap.put("pastHistory", healthInfo.getPastHistory());
-        healthInfoMap.put("familyHistory", healthInfo.getFamilyHistory());
-        healthInfoMap.put("nowMedicine", healthInfo.getNowMedicine());
-        healthInfoMap.put("allergy", healthInfo.getAllergy());
-
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("basic_info", basicInfoMap);
-        requestMap.put("health_info", healthInfoMap);
-        requestMap.put("department", department);
-        requestMap.put("suspected_disease", suspectedDisease);
-        requestMap.put("lat", location.getLat());
-        requestMap.put("lon", location.getLon());
-        requestMap.put("secondary_hospital", secondaryHospital);
-        requestMap.put("tertiary_hospital", tertiaryHospital);
-
-        return requestMap;  // Map 객체를 직접 반환
-    }
 }
+

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/PharmacyService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/PharmacyService.java
@@ -1,32 +1,21 @@
 package com.mediko.mediko_server.domain.recommend.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
-import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.repository.BasicInfoRepository;
-import com.mediko.mediko_server.domain.member.domain.repository.HealthInfoRepository;
-import com.mediko.mediko_server.domain.member.domain.repository.LocationRepository;
-import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.application.converter.PharmacyConverter;
+import com.mediko.mediko_server.domain.recommend.application.factory.PharmacyRequestFactory;
 import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
-import com.mediko.mediko_server.domain.recommend.domain.repository.HospitalRepository;
 import com.mediko.mediko_server.domain.recommend.domain.repository.PharmacyRepository;
-import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
 import com.mediko.mediko_server.domain.recommend.dto.request.PharmacyRequestDTO;
-import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
 import com.mediko.mediko_server.domain.recommend.dto.response.PharmacyResponseDTO;
-import com.mediko.mediko_server.domain.report.domain.Report;
-import com.mediko.mediko_server.domain.report.domain.repository.ReportRepository;
 import com.mediko.mediko_server.global.flask.FlaskCommunicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -35,97 +24,39 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class PharmacyService {
     private final BasicInfoRepository basicInfoRepository;
-    private final LocationRepository locationRepository;
     private final PharmacyRepository pharmacyRepository;
     private final FlaskCommunicationService flaskCommunicationService;
+    private final PharmacyRequestFactory pharmacyRequestFactory;
+    private final PharmacyConverter pharmacyConverter;
 
     @Transactional
     public List<PharmacyResponseDTO> recommendPharmacy(PharmacyRequestDTO requestDTO) {
-        // 1. BasicInfo 및 HealthInfo 조회
+        // 1. BasicInfo 조회
         BasicInfo basicInfo = basicInfoRepository.findById(requestDTO.getBasicInfoId())
                 .orElseThrow(() -> new RuntimeException("BasicInfo not found"));
 
-        Location location = locationRepository.findById(requestDTO.getLocationId())
-                .orElseThrow(() -> new RuntimeException("Location not found"));
+        // 2. Flask 서버에 보낼 요청 데이터 생성
+        Map<String, Object> flaskRequestData = pharmacyRequestFactory.createFlaskRequest(
+                basicInfo, requestDTO.getUserLatitude(), requestDTO.getUserLongitude()
+        );
 
-
-        // 3. Flask 서버에 보낼 요청 데이터 생성
-        Map<String, Object> requestData = buildRequestData(basicInfo, location);
-
-        // 4. Flask 서버로 요청 보내고 전체 응답 받기
-        List<PharmacyResponseDTO> flaskResponses = flaskCommunicationService.getPharmacyRecommendation(requestData);
+        // 3. Flask 서버로 요청 보내고 응답 받기
+        List<PharmacyResponseDTO> flaskResponses = flaskCommunicationService
+                .getPharmacyRecommendation(flaskRequestData);
 
         if (flaskResponses == null || flaskResponses.isEmpty()) {
-            throw new RuntimeException("No hospital recommendations received");
+            throw new RuntimeException("No pharmacy recommendations received");
         }
 
-        // 5. 각 추천 병원에 대해 Hospital 엔티티 생성 및 저장
-        return flaskResponses.stream()
-                .map(flaskResponse -> {
-                    Pharmacy basePharmacy = requestDTO.toEntity(
-                            basicInfo,
-                            location
-                    );
-                    Pharmacy pharmacy = basePharmacy.toBuilder()
-                            .phId(flaskResponse.getPhId())
-                            .maping(flaskResponse.getMaping())
-                            .name(flaskResponse.getName())
-                            .address(flaskResponse.getAddress())
-                            .tel(flaskResponse.getTel())
-                            .latitude(flaskResponse.getLatitude())
-                            .longitude(flaskResponse.getLongitude())
-                            .travelKm(flaskResponse.getTravelKm())
-                            .travelH(flaskResponse.getTravelH())
-                            .travelM(flaskResponse.getTravelM())
-                            .travelS(flaskResponse.getTravelS())
-                            .close1(flaskResponse.getClose1())
-                            .close2(flaskResponse.getClose2())
-                            .close3(flaskResponse.getClose3())
-                            .close4(flaskResponse.getClose4())
-                            .close5(flaskResponse.getClose5())
-                            .close6(flaskResponse.getClose6())
-                            .close7(flaskResponse.getClose7())
-                            .close8(flaskResponse.getClose8())
-                            .start1(flaskResponse.getStart1())
-                            .start2(flaskResponse.getStart2())
-                            .start3(flaskResponse.getStart3())
-                            .start4(flaskResponse.getStart4())
-                            .start5(flaskResponse.getStart5())
-                            .start6(flaskResponse.getStart6())
-                            .start7(flaskResponse.getStart7())
-                            .start8(flaskResponse.getStart8())
-                            .timestamp(flaskResponse.getTimestamp())
-                            .version(flaskResponse.getVersion())
-                            .latLon(flaskResponse.getLatLon())
-                            .postcdn1(flaskResponse.getPostcdn1())
-                            .postcdn2(flaskResponse.getPostcdn2())
-                            .dutyetc(flaskResponse.getDutyetc())
-                            .member(basicInfo.getMember())
-                            .build();
-
-                    Pharmacy savedPharmacy = pharmacyRepository.save(pharmacy);
-                    return PharmacyResponseDTO.fromEntity(savedPharmacy);
-                })
+        // 4. Flask 응답을 엔티티로 변환 후 저장
+        List<Pharmacy> savedPharmacies = flaskResponses.stream()
+                .map(response -> pharmacyConverter.toEntity(response, requestDTO, basicInfo))
+                .map(pharmacyRepository::save)
                 .collect(Collectors.toList());
-    }
 
-
-    private Map<String, Object> buildRequestData(BasicInfo basicInfo,  Location location) {
-        Map<String, Object> basicInfoMap = new HashMap<>();
-        basicInfoMap.put("language", basicInfo.getLanguage().toString());
-        basicInfoMap.put("number", basicInfo.getNumber());
-        basicInfoMap.put("address", basicInfo.getAddress());
-        basicInfoMap.put("gender", basicInfo.getGender().toString());
-        basicInfoMap.put("age", basicInfo.getAge());
-        basicInfoMap.put("height", basicInfo.getHeight());
-        basicInfoMap.put("weight", basicInfo.getWeight());
-
-
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("basic_info", basicInfoMap);
-        requestMap.put("lat", location.getLat());
-        requestMap.put("lon", location.getLon());
-
-        return requestMap;
+        // 5. 저장된 엔티티를 DTO로 변환하여 반환
+        return savedPharmacies.stream()
+                .map(PharmacyResponseDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/ErConverter.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/ErConverter.java
@@ -1,0 +1,37 @@
+package com.mediko.mediko_server.domain.recommend.application.converter;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.HealthInfo;
+import com.mediko.mediko_server.domain.recommend.domain.Er;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.dto.request.ErRequestDTO;
+import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.ErResponseDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
+import com.mediko.mediko_server.domain.report.domain.Report;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ErConverter {
+    public Er toEntity(ErResponseDTO response, ErRequestDTO requestDTO, BasicInfo basicInfo) {
+        return Er.builder()
+                .name(response.getName())
+                .address(response.getAddress())
+                .tel(response.getTel())
+                .hvamyn(response.getHvamyn())
+                .isTrauma(response.getIsTrauma())
+                .userLatitude(requestDTO.getUserLatitude())
+                .userLongitude(requestDTO.getUserLongitude())
+                .isCondition(requestDTO.getIsCondition())
+                .conditions(requestDTO.getConditions())
+                .travelKm(response.getTravelKm())
+                .travelH(response.getTravelH())
+                .travelM(response.getTravelM())
+                .travelS(response.getTravelS())
+                .basicInfo(basicInfo)
+                .member(basicInfo.getMember())
+                .build();
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/HospitalConverter.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/HospitalConverter.java
@@ -1,0 +1,53 @@
+package com.mediko.mediko_server.domain.recommend.application.converter;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.HealthInfo;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
+import com.mediko.mediko_server.domain.report.domain.Report;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class HospitalConverter {
+    public Hospital toEntity(HospitalResponseDTO response, HospitalRequestDTO requestDTO,
+                             String department, String suspectedDisease,
+                             BasicInfo basicInfo, HealthInfo healthInfo, Report report) {
+        return Hospital.builder()
+                .isReport(requestDTO.isReport())
+                .userDepartment(department)
+                .suspectedDisease(requestDTO.isReport() ?
+                        List.of(suspectedDisease.split(",")) : requestDTO.getSuspectedDisease())
+                .secondaryHospital(requestDTO.isSecondaryHospital())
+                .tertiaryHospital(requestDTO.isTertiaryHospital())
+                .userLatitude(requestDTO.getUserLatitude())
+                .userLongitude(requestDTO.getUserLongitude())
+                .hpId(response.getHpId())
+                .name(response.getName())
+                .telephone(response.getTelephone())
+                .hpDepartment(response.getHpDepartment())
+                .hpAddress(response.getHpAddress())
+                .hpLatitude(response.getHpLatitude())
+                .hpLongitude(response.getHpLongitude())
+                .sidocdnm(response.getSidocdnm())
+                .sggucdnm(response.getSggucdnm())
+                .emdongnm(response.getEmdongnm())
+                .clcdnm(response.getClcdnm())
+                .esDistanceInKm(response.getEsDistanceInKm())
+                .travelKm(response.getTravelKm())
+                .travelH(response.getTravelH())
+                .travelM(response.getTravelM())
+                .travelS(response.getTravelS())
+                .sortScore(response.getSortScore())
+                .departmentMatch(response.getDepartmentMatch())
+                .similarity(response.getSimilarity())
+                .url(response.getUrl())
+                .basicInfo(basicInfo)
+                .healthInfo(healthInfo)
+                .report(report)
+                .member(basicInfo.getMember())
+                .build();
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/PharmacyConverter.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/PharmacyConverter.java
@@ -1,0 +1,63 @@
+package com.mediko.mediko_server.domain.recommend.application.converter;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.HealthInfo;
+import com.mediko.mediko_server.domain.member.domain.Location;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
+import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
+import com.mediko.mediko_server.domain.recommend.dto.request.PharmacyRequestDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
+import com.mediko.mediko_server.domain.recommend.dto.response.PharmacyResponseDTO;
+import com.mediko.mediko_server.domain.report.domain.Report;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PharmacyConverter {
+    public Pharmacy toEntity(PharmacyResponseDTO response, PharmacyRequestDTO requestDTO,
+                             BasicInfo basicInfo) {
+        return Pharmacy.builder()
+                .userLatitude(requestDTO.getUserLatitude())
+                .userLongitude(requestDTO.getUserLongitude())
+                .phId(response.getPhId())
+                .name(response.getName())
+                .address(response.getAddress())
+                .tel(response.getTel())
+                .latitude(response.getLatitude())
+                .longitude(response.getLongitude())
+                .start1(response.getStart1())
+                .start2(response.getStart2())
+                .start3(response.getStart3())
+                .start4(response.getStart4())
+                .start5(response.getStart5())
+                .start6(response.getStart6())
+                .start7(response.getStart7())
+                .start8(response.getStart8())
+                .close1(response.getClose1())
+                .close2(response.getClose2())
+                .close3(response.getClose3())
+                .close4(response.getClose4())
+                .close5(response.getClose5())
+                .close6(response.getClose6())
+                .close7(response.getClose7())
+                .close8(response.getClose8())
+                .maping(response.getMaping())
+                .travelKm(response.getTravelKm())
+                .travelH(response.getTravelH())
+                .travelM(response.getTravelM())
+                .travelS(response.getTravelS())
+                .timestamp(response.getTimestamp())
+                .version(response.getVersion())
+                .latLon(response.getLatLon())
+                .postcdn1(response.getPostcdn1())
+                .postcdn2(response.getPostcdn2())
+                .dutyetc(response.getDutyetc())
+                .basicInfo(basicInfo)
+                .member(basicInfo.getMember())
+                .build();
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/ErRequestFactory.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/ErRequestFactory.java
@@ -1,0 +1,31 @@
+package com.mediko.mediko_server.domain.recommend.application.factory;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.Location;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class ErRequestFactory {
+    public Map<String, Object> createFlaskRequest(
+            BasicInfo basicInfo, Double userLatitude, Double userLongitude
+    ) {
+        Map<String, Object> basicInfoMap = new HashMap<>();
+        basicInfoMap.put("language", basicInfo.getLanguage().toString());
+        basicInfoMap.put("number", basicInfo.getNumber());
+        basicInfoMap.put("address", basicInfo.getAddress());
+        basicInfoMap.put("gender", basicInfo.getGender().toString());
+        basicInfoMap.put("age", basicInfo.getAge());
+        basicInfoMap.put("height", basicInfo.getHeight());
+        basicInfoMap.put("weight", basicInfo.getWeight());
+
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("basic_info", basicInfoMap);
+        requestMap.put("lat", userLatitude);
+        requestMap.put("lon", userLongitude);
+
+        return requestMap;
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/HospitalRequestFactory.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/HospitalRequestFactory.java
@@ -1,0 +1,51 @@
+package com.mediko.mediko_server.domain.recommend.application.factory;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.HealthInfo;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class HospitalRequestFactory {
+    public Map<String, Object> createFlaskRequest(
+            BasicInfo basicInfo, HealthInfo healthInfo,
+            Double userLatitude, Double userLongitude,
+            String department, String suspectedDisease,
+            boolean secondaryHospital, boolean tertiaryHospital
+    ) {
+        Map<String, Object> request = new HashMap<>();
+
+        // 1. basic_info 맵 생성
+        Map<String, Object> basicInfoMap = new HashMap<>();
+        basicInfoMap.put("height", basicInfo.getHeight());
+        basicInfoMap.put("age", basicInfo.getAge());
+        basicInfoMap.put("language", basicInfo.getLanguage());
+        basicInfoMap.put("number", basicInfo.getNumber());
+        basicInfoMap.put("address", basicInfo.getAddress());
+        basicInfoMap.put("gender", basicInfo.getGender());
+        basicInfoMap.put("weight", basicInfo.getWeight());
+
+        // 2. health_info 맵 생성
+        Map<String, String> healthInfoMap = new HashMap<>();
+        healthInfoMap.put("pastHistory", healthInfo.getPastHistory());
+        healthInfoMap.put("allergy", healthInfo.getAllergy());
+        healthInfoMap.put("familyHistory", healthInfo.getFamilyHistory());
+        healthInfoMap.put("nowMedicine", healthInfo.getNowMedicine());
+
+        // 3. 전체 요청 데이터 구성
+        request.put("lat", userLatitude);
+        request.put("lon", userLongitude);
+        request.put("basic_info", basicInfoMap);
+        request.put("health_info", healthInfoMap);
+        request.put("department", department);
+        request.put("suspected_disease", Arrays.asList(suspectedDisease.split(",")));  // 문자열을 리스트로 변환
+        request.put("secondary_hospital", secondaryHospital);
+        request.put("tertiary_hospital", tertiaryHospital);
+
+        return request;
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/PharmacyRequestFactory.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/factory/PharmacyRequestFactory.java
@@ -1,0 +1,31 @@
+package com.mediko.mediko_server.domain.recommend.application.factory;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class PharmacyRequestFactory {
+    public Map<String, Object> createFlaskRequest(
+            BasicInfo basicInfo, Double userLatitude, Double userLongitude
+    ) {
+        Map<String, Object> basicInfoMap = new HashMap<>();
+        basicInfoMap.put("language", basicInfo.getLanguage().toString());
+        basicInfoMap.put("number", basicInfo.getNumber());
+        basicInfoMap.put("address", basicInfo.getAddress());
+        basicInfoMap.put("gender", basicInfo.getGender().toString());
+        basicInfoMap.put("age", basicInfo.getAge());
+        basicInfoMap.put("height", basicInfo.getHeight());
+        basicInfoMap.put("weight", basicInfo.getWeight());
+
+
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("basic_info", basicInfoMap);
+        requestMap.put("lat", userLatitude);
+        requestMap.put("lon", userLongitude);
+
+        return requestMap;
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Er.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Er.java
@@ -58,9 +58,11 @@ public class Er extends BaseEntity {
     @Convert(converter = LongListConverter.class)
     private List<Long> conditions = new ArrayList<>();
 
-    @ManyToOne
-    @JoinColumn(name = "location_id")
-    private Location location;
+    @Column(name = "u_latitude")
+    private Double userLatitude;
+
+    @Column(name = "u_longitude")
+    private Double userLongitude;
 
     @ManyToOne
     @JoinColumn(name = "basic_info_id", nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Hospital.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Hospital.java
@@ -2,9 +2,7 @@ package com.mediko.mediko_server.domain.recommend.domain;
 
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.Member;
-import com.mediko.mediko_server.domain.openai.domain.Symptom;
 import com.mediko.mediko_server.domain.report.domain.Report;
 import com.mediko.mediko_server.global.converter.StringListConvert;
 import com.mediko.mediko_server.global.domain.BaseEntity;
@@ -28,8 +26,8 @@ public class Hospital extends BaseEntity {
     @Column(name = "is_report", nullable = false)
     private boolean isReport;
 
-    @Column(name = "department", nullable = false)
-    private String department;
+    @Column(name = "u_department", nullable = false)
+    private String userDepartment;
 
     @Convert(converter = StringListConvert.class)
     @Column(name = "disease", nullable = false)
@@ -41,6 +39,11 @@ public class Hospital extends BaseEntity {
     @Column(name = "tertiary_hp", nullable = false)
     private boolean tertiaryHospital;
 
+    @Column(name = "u_latitude")
+    private Double userLatitude;
+
+    @Column(name = "u_longitude")
+    private Double userLongitude;
 
     @Column(name = "hp_id", nullable = false)
     private Long hpId;
@@ -48,20 +51,23 @@ public class Hospital extends BaseEntity {
     @Column(name = "hp_name", nullable = false)
     private String name;
 
-    @Column(name = "hp_address")
-    private String address;
-
     @Column(name = "hp_telephone", nullable = false)
     private String telephone;
 
-    @Column(name = "latitude")
-    private Double latitude;
+    @Column(name = "hp_department", nullable = false)
+    private String hpDepartment;
 
-    @Column(name = "longitude")
-    private Double longitude;
+    @Column(name = "hp_address")
+    private String hpAddress;
 
-    @Column(name = "es_distance_in_km")
-    private Double esDistanceInKm;
+    @Column(name = "hp_latitude")
+    private Double hpLatitude;
+
+    @Column(name = "hp_longitude")
+    private Double hpLongitude;
+
+    @Transient
+    private List<Double> latLon;
 
     @Column(name = "sidocdnm")
     private String sidocdnm;
@@ -75,20 +81,8 @@ public class Hospital extends BaseEntity {
     @Column(name = "clcdnm")
     private String clcdnm;
 
-    @Column(name = "hp_url")
-    private String url;
-
-    @Column(name = "sort_score")
-    private Long sortScore;
-
-    @Column(name = "department_match")
-    private boolean departmentMatch;
-
-    @Transient
-    private List<Double> latLon;
-
-    @Column(name = "similarity")
-    private Double similarity;
+    @Column(name = "es_distance_in_km")
+    private Double esDistanceInKm;
 
     @Column(name = "travle_km")
     private Double travelKm;
@@ -102,10 +96,18 @@ public class Hospital extends BaseEntity {
     @Column(name = "trevel_s")
     private Integer travelS;
 
+    @Column(name = "sort_score")
+    private Long sortScore;
 
-    @ManyToOne
-    @JoinColumn(name = "location_id")
-    private Location location;
+    @Column(name = "department_match")
+    private boolean departmentMatch;
+
+    @Column(name = "similarity")
+    private Double similarity;
+
+    @Column(name = "hp_url")
+    private String url;
+
 
     @ManyToOne
     @JoinColumn(name = "basic_info_id", nullable = false)
@@ -124,7 +126,7 @@ public class Hospital extends BaseEntity {
     private Member member;
 
     public List<Double> getLatLon() {
-        return Arrays.asList(longitude, latitude);
+        return Arrays.asList(hpLatitude, hpLongitude);
     }
 
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Pharmacy.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Pharmacy.java
@@ -1,11 +1,8 @@
 package com.mediko.mediko_server.domain.recommend.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
-import com.mediko.mediko_server.domain.member.domain.HealthInfo;
 import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.Member;
-import com.mediko.mediko_server.domain.report.domain.Report;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -13,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,10 +36,10 @@ public class Pharmacy extends BaseEntity {
     @Column(name = "ph_tel")
     private String tel;
 
-    @Column(name = "latitude")
+    @Column(name = "hpLatitude")
     private Double latitude;
 
-    @Column(name = "longitude")
+    @Column(name = "hpLongitude")
     private Double longitude;
 
     @Column(name = "travle_km")
@@ -124,10 +120,11 @@ public class Pharmacy extends BaseEntity {
     @Transient
     private String dutyetc;
 
+    @Column(name = "u_latitude")
+    private Double userLatitude;
 
-    @ManyToOne
-    @JoinColumn(name = "location_id")
-    private Location location;
+    @Column(name = "u_longitude")
+    private Double userLongitude;
 
     @ManyToOne
     @JoinColumn(name = "basic_info_id", nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/ErRequestDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/ErRequestDTO.java
@@ -1,10 +1,12 @@
 package com.mediko.mediko_server.domain.recommend.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.recommend.domain.Conditions;
 import com.mediko.mediko_server.domain.recommend.domain.Er;
 import io.micrometer.common.lang.Nullable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,23 +16,27 @@ import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ErRequestDTO {
 
     private Long basicInfoId;
 
-    @Nullable
-    private Long locationId;
+    @JsonProperty("lat")
+    private Double userLatitude;
+
+    @JsonProperty("lon")
+    private Double userLongitude;
 
     private Boolean isCondition;
 
     private List<Long> conditions;
 
 
-    public Er toEntity(BasicInfo basicInfo, Location location) {
-
+    public Er toEntity(BasicInfo basicInfo) {
         return Er.builder()
                 .basicInfo(basicInfo)
-                .location(location)
+                .userLatitude(this.userLatitude)
+                .userLongitude(this.userLongitude)
                 .isCondition(this.isCondition)
                 .conditions(conditions)
                 .build();

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/HospitalRequestDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/HospitalRequestDTO.java
@@ -3,9 +3,7 @@ package com.mediko.mediko_server.domain.recommend.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.recommend.domain.Hospital;
-import io.micrometer.common.lang.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,32 +19,40 @@ public class HospitalRequestDTO {
 
     private Long healthInfoId;
 
-    @Nullable
-    private Long locationId;
+    @JsonProperty("lat")
+    private Double userLatitude;
+
+    @JsonProperty("lon")
+    private Double userLongitude;
 
     @JsonProperty("is_report")
     private boolean isReport;
 
     private Long reportId;
 
-    private String department;
+    @JsonProperty("department")
+    private String userDepartment;
 
+    @JsonProperty("suspected_disease")
     private List<String> suspectedDisease;
 
-    private boolean secondary_hospital;
+    @JsonProperty("secondary_hospital")
+    private boolean secondaryHospital;
 
-    private boolean tertiary_hospital;
+    @JsonProperty("tertiary_hospital")
+    private boolean tertiaryHospital;
 
-    public Hospital toEntity(BasicInfo basicInfo, HealthInfo healthInfo, String department, String suspectedDisease, Location location) {
+    public Hospital toEntity(BasicInfo basicInfo, HealthInfo healthInfo) {
         return Hospital.builder()
+                .userLatitude(this.userLatitude)
+                .userLongitude(this.userLongitude)
                 .isReport(this.isReport)
-                .department(department)
-                .suspectedDisease(List.of(suspectedDisease.split(",")))
-                .secondaryHospital(this.secondary_hospital)
-                .tertiaryHospital(this.tertiary_hospital)
+                .userDepartment(this.userDepartment)
+                .suspectedDisease(this.suspectedDisease)
+                .secondaryHospital(this.secondaryHospital)
+                .tertiaryHospital(this.tertiaryHospital)
                 .basicInfo(basicInfo)
                 .healthInfo(healthInfo)
-                .location(location)
                 .build();
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/PharmacyRequestDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/request/PharmacyRequestDTO.java
@@ -1,25 +1,32 @@
 package com.mediko.mediko_server.domain.recommend.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
 import io.micrometer.common.lang.Nullable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PharmacyRequestDTO {
 
     private Long basicInfoId;
 
-    @Nullable
-    private Long locationId;
+    @JsonProperty("lat")
+    private Double userLatitude;
 
-    public Pharmacy toEntity(BasicInfo basicInfo, Location location) {
+    @JsonProperty("lon")
+    private Double userLongitude;
+
+    public Pharmacy toEntity(BasicInfo basicInfo) {
         return Pharmacy.builder()
                 .basicInfo(basicInfo)
-                .location(location)
+                .userLatitude(this.userLatitude)
+                .userLongitude(this.userLongitude)
                 .build();
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/response/HospitalResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/response/HospitalResponseDTO.java
@@ -2,7 +2,6 @@ package com.mediko.mediko_server.domain.recommend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mediko.mediko_server.domain.recommend.domain.Hospital;
-import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,23 +19,23 @@ public class HospitalResponseDTO {
     @JsonProperty("name")
     private String name;
 
-    @JsonProperty("address")
-    private String address;
+    @JsonProperty("department")
+    private String hpDepartment;
 
     @JsonProperty("telephone")
     private String telephone;
 
-    @JsonProperty("department")
-    private String department;
+    @JsonProperty("address")
+    private String hpAddress;
 
     @JsonProperty("latitude")
-    private Double latitude;
+    private Double hpLatitude;
 
     @JsonProperty("longitude")
-    private Double longitude;
+    private Double hpLongitude;
 
-    @JsonProperty("es_distance_in_km")
-    private Double esDistanceInKm;
+    @JsonProperty("location")
+    private List<Double> latLon;
 
     @JsonProperty("sidocdnm")
     private String sidocdnm;
@@ -50,21 +49,8 @@ public class HospitalResponseDTO {
     @JsonProperty("clcdnm")
     private String clcdnm;
 
-    @JsonProperty("url")
-    private String url;
-
-    @JsonProperty("sort_score")
-    private Long sortScore;
-
-    @JsonProperty("department_match")
-    private Boolean departmentMatch;
-
-    @JsonProperty("location")
-    @Transient
-    private List<Double> latLon;
-
-    @JsonProperty("similarity")
-    private Double similarity;
+    @JsonProperty("es_distance_in_km")
+    private Double esDistanceInKm;
 
     @JsonProperty("transit_travel_distance_km")
     private Double travelKm;
@@ -78,30 +64,41 @@ public class HospitalResponseDTO {
     @JsonProperty("transit_travel_time_s")
     private Integer travelS;
 
+    @JsonProperty("sort_score")
+    private Long sortScore;
+
+    @JsonProperty("department_match")
+    private Boolean departmentMatch;
+
+    @JsonProperty("similarity")
+    private Double similarity;
+
+    @JsonProperty("url")
+    private String url;
 
     public static HospitalResponseDTO fromEntity(Hospital hospital) {
         return new HospitalResponseDTO(
                 hospital.getHpId(),
                 hospital.getName(),
-                hospital.getAddress(),
+                hospital.getHpDepartment(),
                 hospital.getTelephone(),
-                hospital.getDepartment(),
-                hospital.getLatitude(),
-                hospital.getLongitude(),
-                hospital.getEsDistanceInKm(),
+                hospital.getHpAddress(),
+                hospital.getHpLatitude(),
+                hospital.getHpLongitude(),
+                hospital.getLatLon(),
                 hospital.getSidocdnm(),
                 hospital.getSggucdnm(),
                 hospital.getEmdongnm(),
                 hospital.getClcdnm(),
-                hospital.getUrl(),
-                hospital.getSortScore(),
-                hospital.isDepartmentMatch(),
-                hospital.getLatLon(),
-                hospital.getSimilarity(),
+                hospital.getEsDistanceInKm(),
                 hospital.getTravelKm(),
                 hospital.getTravelH(),
                 hospital.getTravelM(),
-                hospital.getTravelS()
+                hospital.getTravelS(),
+                hospital.getSortScore(),
+                hospital.isDepartmentMatch(),
+                hospital.getSimilarity(),
+                hospital.getUrl()
         );
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/dto/response/PharmacyResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/dto/response/PharmacyResponseDTO.java
@@ -1,14 +1,12 @@
 package com.mediko.mediko_server.domain.recommend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mediko.mediko_server.domain.recommend.domain.Hospital;
 import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
 import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
@@ -3,9 +3,7 @@ package com.mediko.mediko_server.domain.report.domain;
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.domain.Symptom;
-import com.mediko.mediko_server.global.converter.JsonConverter;
-import com.mediko.mediko_server.global.converter.StringListConvert;
-import com.mediko.mediko_server.global.converter.StringListMapConverter;
+import com.mediko.mediko_server.global.converter.*;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -25,19 +23,19 @@ import java.util.Map;
 @Entity
 @Table(name= "report")
 public class Report extends BaseEntity {
-    @Convert(converter = JsonConverter.class)
+    @Convert(converter = SingleObjectMapConverter.class)
     @Column(name = "department")
     private Map<String, Object> recommendedDepartment;
 
-    @Convert(converter = JsonConverter.class)
+    @Convert(converter = StringMapListConverter.class)
     @Column(name = "conditions")
    private List<Map<String, String>> possibleConditions = new ArrayList<>();
 
-    @Convert(converter = JsonConverter.class)
+    @Convert(converter = StringMapListConverter.class)
     @Column(name = "questions")
     private List<Map<String, String>> questionsForDoctor = new ArrayList<>();
 
-    @Convert(converter = JsonConverter.class)
+    @Convert(converter = ObjectMapListConverter.class)
     @Column(name = "checklist")
     private List<Map<String, Object>> symptomChecklist = new ArrayList<>();
 

--- a/src/main/java/com/mediko/mediko_server/global/converter/ObjectMapListConverter.java
+++ b/src/main/java/com/mediko/mediko_server/global/converter/ObjectMapListConverter.java
@@ -1,0 +1,36 @@
+package com.mediko.mediko_server.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ObjectMapListConverter  implements AttributeConverter<List<Map<String, Object>>, String> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Map<String, Object>> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting to JSON", e);
+        }
+    }
+
+    @Override
+    public List<Map<String, Object>> convertToEntityAttribute(String dbData) {
+        try {
+            if (dbData == null) {
+                return new ArrayList<>();
+            }
+            return objectMapper.readValue(dbData,
+                    new TypeReference<List<Map<String, Object>>>() {});
+        } catch (JsonProcessingException e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/global/converter/SingleObjectMapConverter.java
+++ b/src/main/java/com/mediko/mediko_server/global/converter/SingleObjectMapConverter.java
@@ -1,0 +1,40 @@
+package com.mediko.mediko_server.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Converter
+public class SingleObjectMapConverter implements AttributeConverter<Map<String, Object>, String> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting to JSON", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        try {
+            if (dbData == null) {
+                return new HashMap<>();
+            }
+            return objectMapper.readValue(dbData,
+                    new TypeReference<Map<String, Object>>() {
+                    });
+        } catch (JsonProcessingException e) {
+            return new HashMap<>(); // 에러 발생시 빈 맵 반환
+        }
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/global/converter/StringMapListConverter.java
+++ b/src/main/java/com/mediko/mediko_server/global/converter/StringMapListConverter.java
@@ -1,0 +1,48 @@
+package com.mediko.mediko_server.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Converter
+public class StringMapListConverter implements AttributeConverter<List<Map<String, Object>>, String> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Map<String, Object>> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+
+    @Override
+    public List<Map<String, Object>> convertToEntityAttribute(String dbData) {
+        try {
+            JavaType type = objectMapper.getTypeFactory().constructParametricType(
+                    List.class,
+                    objectMapper.getTypeFactory().constructParametricType(
+                            Map.class,
+                            String.class,
+                            Object.class
+                    )
+            );
+
+            if (dbData == null || dbData.isEmpty()) {
+                return new ArrayList<>();
+            }
+            return objectMapper.readValue(dbData, type);
+        } catch (JsonProcessingException e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/global/flask/FlaskCommunicationService.java
+++ b/src/main/java/com/mediko/mediko_server/global/flask/FlaskCommunicationService.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ public class FlaskCommunicationService {
                 new ParameterizedTypeReference<List<ErResponseDTO>>() {});
     }
 
+
     private <T> T sendRequestToFlask(Object requestData, String endpoint, Class<T> responseType) {
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -68,6 +70,7 @@ public class FlaskCommunicationService {
         }
     }
 
+
     private <T> T sendRequestToFlask(Object requestData, String endpoint,
                                      ParameterizedTypeReference<T> responseType) {
         try {
@@ -75,12 +78,19 @@ public class FlaskCommunicationService {
             headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<Object> entity = new HttpEntity<>(requestData, headers);
 
+            // 요청 데이터 로깅 추가
+            log.info("Flask 서버로 보내는 데이터: {}", requestData);
+            log.info("Flask 서버 엔드포인트: {}", flaskBaseUrl + endpoint);
+
             ResponseEntity<T> response = restTemplate.exchange(
                     flaskBaseUrl + endpoint,
                     HttpMethod.POST,
                     entity,
                     responseType
             );
+
+            // 응답 데이터 로깅 추가
+            log.info("Flask 서버 응답: {}", response.getBody());
 
             return response.getBody();
         } catch (Exception e) {

--- a/src/main/java/com/mediko/mediko_server/global/flask/FlaskUrls.java
+++ b/src/main/java/com/mediko/mediko_server/global/flask/FlaskUrls.java
@@ -18,4 +18,7 @@ public class FlaskUrls {
 
     @Value("${flask.urls.recommend_hospital}")
     private String recommendHospital;
+
+    @Value("${flask.urls.geocode}")
+    private String geoLocation;
 }

--- a/src/main/java/com/mediko/mediko_server/global/security/SecurityConfig.java
+++ b/src/main/java/com/mediko/mediko_server/global/security/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:8081"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #16 
### 🔑 주요 변경사항
- request의 주소를 lat과 lon으로 받는 것으로 통일
- hospital의 request에서 report를 선택할 시 예상병명과 진료과 자동으로 넣어서 flask와 연결되도록 수정
- jsonconverter를 각 타입에 맞게 세분화
- ResponseDTO, RequestDTO, BasicInfo, HealthInfo 등의 정보를 조합해서 엔티티로 변환하는 Mapper 클래스 따로 생성

