### PR TITLE
feat: 네이버, 카카오, 구글 map url scheme 구현

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/map/application/MapUrlGenerator.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/application/MapUrlGenerator.java
@@ -1,0 +1,49 @@
+package com.mediko.mediko_server.domain.map.application;
+
+import lombok.Getter;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+public class MapUrlGenerator {
+
+    // Naver 지도 URL 생성
+    public static String generateNaverMapUrl(
+            double userLatitude, double userLongitude, // 사용자 위치
+            double hpLatitude, double hpLongitude, // 병원 위치
+            String hpName, String appName // 병원 이름, 앱 패키지명
+    ) {
+        return String.format(
+                "nmap://route/walk?slat=%f&slng=%f&dlat=%f&dlng=%f&dname=%s&appname=%s",
+                userLatitude, userLongitude, // 출발지: 사용자 위치
+                hpLatitude, hpLongitude, // 도착지: 병원 위치
+                URLEncoder.encode(hpName, StandardCharsets.UTF_8), // 병원 이름 인코딩
+                URLEncoder.encode(appName, StandardCharsets.UTF_8) // 앱 패키지명 인코딩
+        );
+    }
+
+    // Kakao 지도 URL 생성
+    public static String generateKakaoMapUrl(
+            double userLatitude, double userLongitude, // 사용자 위치
+            double hpLatitude, double hpLongitude // 병원 위치
+    ) {
+        return String.format(
+                "kakaomap://route?sp=%f,%f&ep=%f,%f&by=FOOT",
+                userLatitude, userLongitude, // 출발지: 사용자 위치
+                hpLatitude, hpLongitude // 도착지: 병원 위치
+        );
+    }
+
+    // Google 지도 URL 생성
+    public static String generateGoogleMapUrl(
+            double userLatitude, double userLongitude, // 사용자 위치
+            double hpLatitude, double hpLongitude // 병원 위치
+    ) {
+        return String.format(
+                "https://www.google.com/maps/dir/?api=1&origin=%f,%f&destination=%f,%f&travelmode=walking",
+                userLatitude, userLongitude, // 출발지: 사용자 위치
+                hpLatitude, hpLongitude // 도착지: 병원 위치
+        );
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedErService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedErService.java
@@ -1,0 +1,84 @@
+package com.mediko.mediko_server.domain.map.application;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedEr;
+import com.mediko.mediko_server.domain.map.domain.repository.SelectedErRepository;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedErResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Er;
+import com.mediko.mediko_server.domain.recommend.domain.repository.ErRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SelectedErService {
+    /*
+
+    private final SelectedErRepository selectedErRepository;
+    private final ErRepository erRepository;
+
+    @Value("${app.name}")
+    private String appName;
+
+    // 응급실 선택 및 저장
+    public SelectedErResponseDTO saveSelectedEr(Long erId, Member member, String appName) {
+        Er er = erRepository.findById(erId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 응급실을 찾을 수 없습니다."));
+
+        double userLatitude = er.getUserLatitude();
+        double userLongitude = er.getUserLongitude();
+        double erLatitude = er.getErLatitude();
+        double erLongitude = er.getErLongitude();
+        String erName = er.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude, erName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude
+        );
+
+        SelectedEr selectedEr = selectedErRepository.save(
+                SelectedEr.builder()
+                        .er(er)
+                        .member(member)
+                        .naverMap(naverMapUrl)
+                        .kakaoMap(kakaoMapUrl)
+                        .googleMap(googleMapUrl)
+                        .build()
+        );
+
+        return SelectedErResponseDTO.fromEntity(er, selectedEr);
+    }
+
+    // 지도 URL 조회
+    public MapUrlResponseDTO getMapUrlsForEr(Long erId) {
+        Er er = erRepository.findById(erId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 응급실을 찾을 수 없습니다."));
+
+        double userLatitude = er.getUserLatitude();
+        double userLongitude = er.getUserLongitude();
+        double erLatitude = er.getErLatitude();
+        double erLongitude = er.getErLongitude();
+        String erName = er.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude, erName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, erLatitude, erLongitude
+        );
+
+        return new MapUrlResponseDTO(naverMapUrl, kakaoMapUrl, googleMapUrl);
+    }
+
+    */
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedHospitalService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedHospitalService.java
@@ -1,0 +1,86 @@
+package com.mediko.mediko_server.domain.map.application;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedHospital;
+import com.mediko.mediko_server.domain.map.domain.repository.SelectedHospitalRepository;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedHospitalResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.domain.repository.HospitalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+public class SelectedHospitalService {
+
+    private final SelectedHospitalRepository selectedHospitalRepository;
+    private final HospitalRepository hospitalRepository;
+
+    @Value("${app.name}")
+    private String appName;
+
+    // 병원 선택 및 저장
+    public SelectedHospitalResponseDTO saveSelectedHospital(Long hospitalId, Member member, String appName) {
+        Hospital hospital = hospitalRepository.findById(hospitalId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 병원을 찾을 수 없습니다."));
+
+        double userLatitude = hospital.getUserLatitude();
+        double userLongitude = hospital.getUserLongitude();
+        double hospitalLatitude = hospital.getHpLatitude();
+        double hospitalLongitude = hospital.getHpLongitude();
+        String hospitalName = hospital.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude, hospitalName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude
+        );
+
+        SelectedHospital selectedHospital = selectedHospitalRepository.save(
+                SelectedHospital.builder()
+                        .hospital(hospital)
+                        .member(member)
+                        .naverMap(naverMapUrl)
+                        .kakaoMap(kakaoMapUrl)
+                        .googleMap(googleMapUrl)
+                        .build()
+        );
+
+        return SelectedHospitalResponseDTO.fromEntity(hospital, selectedHospital);
+    }
+
+    // 지도 URL 조회
+    public MapUrlResponseDTO getMapUrlsForHospital(Long hospitalId) {
+        Hospital hospital = hospitalRepository.findById(hospitalId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 병원을 찾을 수 없습니다."));
+
+        double userLatitude = hospital.getUserLatitude();
+        double userLongitude = hospital.getUserLongitude();
+        double hospitalLatitude = hospital.getHpLatitude();
+        double hospitalLongitude = hospital.getHpLongitude();
+        String hospitalName = hospital.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude, hospitalName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, hospitalLatitude, hospitalLongitude
+        );
+
+        return new MapUrlResponseDTO(naverMapUrl, kakaoMapUrl, googleMapUrl);
+    }
+}
+
+

--- a/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedPharmacyService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/application/SelectedPharmacyService.java
@@ -1,0 +1,80 @@
+package com.mediko.mediko_server.domain.map.application;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedPharmacy;
+import com.mediko.mediko_server.domain.map.domain.repository.SelectedPharmacyRepostiroy;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedPharmacyResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
+import com.mediko.mediko_server.domain.recommend.domain.repository.PharmacyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SelectedPharmacyService {
+    private final SelectedPharmacyRepostiroy selectedPharmacyRepostiroy;
+    private final PharmacyRepository pharmacyRepository;
+
+    @Value("${app.name}")
+    private String appName;
+
+    // 약국 선택 및 저장
+    public SelectedPharmacyResponseDTO saveSelectedPharmacy(Long pharmacyId, Member member, String appName) {
+        Pharmacy pharmacy = pharmacyRepository.findById(pharmacyId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약국을 찾을 수 없습니다."));
+
+        double userLatitude = pharmacy.getUserLatitude();
+        double userLongitude = pharmacy.getUserLongitude();
+        double pharmacyLatitude = pharmacy.getPhLatitude();
+        double pharmacyLongitude = pharmacy.getPhLongitude();
+        String pharmacyName = pharmacy.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, pharmacyLatitude, pharmacyLongitude, pharmacyName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, pharmacyLatitude, pharmacyLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, pharmacyLatitude, pharmacyLongitude
+        );
+
+        SelectedPharmacy selectedPharmacy = selectedPharmacyRepostiroy.save(
+                SelectedPharmacy.builder()
+                        .pharmacy(pharmacy)
+                        .member(member)
+                        .naverMap(naverMapUrl)
+                        .kakaoMap(kakaoMapUrl)
+                        .googleMap(googleMapUrl)
+                        .build()
+        );
+
+        return SelectedPharmacyResponseDTO.fromEntity(pharmacy, selectedPharmacy);
+    }
+
+    // 지도 URL 조회
+    public MapUrlResponseDTO getMapUrlsForPharmacy(Long pharamacyId) {
+        Pharmacy pharmacy = pharmacyRepository.findById(pharamacyId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약국을 찾을 수 없습니다."));
+
+        double userLatitude = pharmacy.getUserLatitude();
+        double userLongitude = pharmacy.getUserLongitude();
+        double PharmacyLatitude = pharmacy.getPhLatitude();
+        double PharmacyLongitude = pharmacy.getPhLongitude();
+        String pharmacyName = pharmacy.getName();
+
+        String naverMapUrl = MapUrlGenerator.generateNaverMapUrl(
+                userLatitude, userLongitude, PharmacyLatitude, PharmacyLongitude, pharmacyName, appName
+        );
+        String kakaoMapUrl = MapUrlGenerator.generateKakaoMapUrl(
+                userLatitude, userLongitude, PharmacyLatitude, PharmacyLongitude
+        );
+        String googleMapUrl = MapUrlGenerator.generateGoogleMapUrl(
+                userLatitude, userLongitude, PharmacyLatitude, PharmacyLongitude
+        );
+
+        return new MapUrlResponseDTO(naverMapUrl, kakaoMapUrl, googleMapUrl);
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedEr.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedEr.java
@@ -1,0 +1,36 @@
+package com.mediko.mediko_server.domain.map.domain;
+
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Er;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "selected_er")
+public class SelectedEr extends BaseEntity {
+    @Column(name = "naver_map", nullable = false)
+    private String naverMap;
+
+    @Column(name = "kakao_map", nullable = false)
+    private String kakaoMap;
+
+    @Column(name = "google_map", nullable = false)
+    private String googleMap;
+
+    @ManyToOne
+    @JoinColumn(name = "er_id", nullable = false)
+    private Er er;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedHospital.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedHospital.java
@@ -1,0 +1,36 @@
+package com.mediko.mediko_server.domain.map.domain;
+
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "selected_hp")
+public class SelectedHospital extends BaseEntity {
+
+    @Column(name = "naver_map", nullable = false)
+    private String naverMap;
+
+    @Column(name = "kakao_map", nullable = false)
+    private String kakaoMap;
+
+    @Column(name = "google_map", nullable = false)
+    private String googleMap;
+
+    @ManyToOne
+    @JoinColumn(name = "hospital_id", nullable = false)
+    private Hospital hospital;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedPharmacy.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedPharmacy.java
@@ -1,0 +1,37 @@
+package com.mediko.mediko_server.domain.map.domain;
+
+import com.mediko.mediko_server.domain.member.domain.Member;
+import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
+import com.mediko.mediko_server.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "selected_pharmacy")
+public class SelectedPharmacy extends BaseEntity {
+
+    @Column(name = "naver_map", nullable = false)
+    private String naverMap;
+
+    @Column(name = "kakao_map", nullable = false)
+    private String kakaoMap;
+
+    @Column(name = "google_map", nullable = false)
+    private String googleMap;
+
+    @ManyToOne
+    @JoinColumn(name = "pharmacy_id", nullable = false)
+    private Pharmacy pharmacy;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedErRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedErRepository.java
@@ -1,0 +1,7 @@
+package com.mediko.mediko_server.domain.map.domain.repository;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedEr;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SelectedErRepository extends JpaRepository<SelectedEr, Long> {
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedHospitalRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedHospitalRepository.java
@@ -1,0 +1,7 @@
+package com.mediko.mediko_server.domain.map.domain.repository;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedHospital;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SelectedHospitalRepository extends JpaRepository<SelectedHospital, Long> {
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedPharmacyRepostiroy.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/repository/SelectedPharmacyRepostiroy.java
@@ -1,0 +1,7 @@
+package com.mediko.mediko_server.domain.map.domain.repository;
+
+import com.mediko.mediko_server.domain.map.domain.SelectedPharmacy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SelectedPharmacyRepostiroy extends JpaRepository<SelectedPharmacy, Long> {
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/dto/response/MapUrlResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/dto/response/MapUrlResponseDTO.java
@@ -1,0 +1,21 @@
+package com.mediko.mediko_server.domain.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MapUrlResponseDTO {
+
+    @JsonProperty("naver_map")
+    private String naverMap;
+
+    @JsonProperty("kakao_map")
+    private String kakaoMap;
+
+    @JsonProperty("google_map")
+    private String googleMap;
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedErResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedErResponseDTO.java
@@ -1,0 +1,56 @@
+package com.mediko.mediko_server.domain.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mediko.mediko_server.domain.map.domain.SelectedEr;
+import com.mediko.mediko_server.domain.recommend.domain.Er;
+import com.mediko.mediko_server.domain.recommend.dto.response.ErResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelectedErResponseDTO {
+    @JsonProperty("dutyName")
+    private String name;
+
+    @JsonProperty("dutyAddr")
+    private String address;
+
+    @JsonProperty("dutyTel3")
+    private String tel;
+
+    @JsonProperty("hvamyn")
+    private String hvamyn;
+
+    @JsonProperty("is_trauma")
+    private Boolean isTrauma;
+
+    @JsonProperty("transit_travel_distance_km")
+    private Double travelKm;
+
+    @JsonProperty("transit_travel_time_h")
+    private Integer travelH;
+
+    @JsonProperty("transit_travel_time_m")
+    private Integer travelM;
+
+    @JsonProperty("transit_travel_time_s")
+    private Integer travelS;
+
+
+    public static SelectedErResponseDTO fromEntity(Er er, SelectedEr selectedEr) {
+        return new SelectedErResponseDTO(
+                er.getName(),
+                er.getAddress(),
+                er.getTel(),
+                er.getHvamyn(),
+                er.getIsTrauma(),
+                er.getTravelKm(),
+                er.getTravelH(),
+                er.getTravelM(),
+                er.getTravelS()
+        );
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedHospitalResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedHospitalResponseDTO.java
@@ -1,7 +1,9 @@
-package com.mediko.mediko_server.domain.recommend.dto.response;
+package com.mediko.mediko_server.domain.map.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mediko.mediko_server.domain.map.domain.SelectedHospital;
 import com.mediko.mediko_server.domain.recommend.domain.Hospital;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +13,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class HospitalResponseDTO {
-
+public class SelectedHospitalResponseDTO {
     @JsonProperty("id")
     private Long hpId;
 
@@ -76,8 +77,10 @@ public class HospitalResponseDTO {
     @JsonProperty("url")
     private String url;
 
-    public static HospitalResponseDTO fromEntity(Hospital hospital) {
-        return new HospitalResponseDTO(
+
+    public static SelectedHospitalResponseDTO fromEntity(
+            Hospital hospital, SelectedHospital selectedHospital) {
+        return new SelectedHospitalResponseDTO(
                 hospital.getHpId(),
                 hospital.getName(),
                 hospital.getHpDepartment(),

--- a/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedPharmacyResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/dto/response/SelectedPharmacyResponseDTO.java
@@ -1,6 +1,7 @@
-package com.mediko.mediko_server.domain.recommend.dto.response;
+package com.mediko.mediko_server.domain.map.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mediko.mediko_server.domain.map.domain.SelectedPharmacy;
 import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
 import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class PharmacyResponseDTO {
+public class SelectedPharmacyResponseDTO {
     @JsonProperty("id")
     private Long phId;
 
@@ -28,11 +29,11 @@ public class PharmacyResponseDTO {
     @JsonProperty("dutytel1")
     private String tel;
 
-    @JsonProperty("latitude")
-    private Double phLatitude;
+    @JsonProperty("phLatitude")
+    private Double latitude;
 
     @JsonProperty("longitude")
-    private Double phLongitude;
+    private Double longitude;
 
     @JsonProperty("transit_travel_distance_km")
     private Double travelKm;
@@ -117,8 +118,9 @@ public class PharmacyResponseDTO {
     @JsonProperty("dutyetc")
     private String dutyetc;
 
-    public static PharmacyResponseDTO fromEntity(Pharmacy pharmacy) {
-        return new PharmacyResponseDTO(
+    public static SelectedPharmacyResponseDTO fromEntity(
+            Pharmacy pharmacy, SelectedPharmacy selectedPharmacy) {
+        return new SelectedPharmacyResponseDTO(
                 pharmacy.getPhId(),
                 pharmacy.getMaping(),
                 pharmacy.getName(),

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelecedErController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelecedErController.java
@@ -1,0 +1,46 @@
+package com.mediko.mediko_server.domain.map.presentation;
+
+import com.mediko.mediko_server.domain.map.application.SelectedErService;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedErResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/selecte-er")
+@RequiredArgsConstructor
+public class SelecedErController {
+    /*
+    private final SelectedErService selectedErService;
+
+    @Value("${app.name}")
+    private String appName;
+
+    //응급실 선택 및 저장
+    @PostMapping("/{erId}")
+    public ResponseEntity<SelectedErResponseDTO> saveSelectedEr(
+            @PathVariable Long erId,
+            @AuthenticationPrincipal Member member
+    ) {
+        SelectedErResponseDTO response = selectedErService
+                .saveSelectedEr(erId, member, appName);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+
+    //응급실 병원의 지도 URL 조회
+    @GetMapping("/{erId}/maps")
+    public ResponseEntity<MapUrlResponseDTO> getMapUrlsForEr(
+            @PathVariable Long erId
+    ) {
+        MapUrlResponseDTO response = selectedErService.getMapUrlsForEr(erId);
+        return ResponseEntity.ok(response);
+    }
+    */
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedHospitalController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedHospitalController.java
@@ -1,0 +1,45 @@
+package com.mediko.mediko_server.domain.map.presentation;
+
+
+import com.mediko.mediko_server.domain.map.application.SelectedHospitalService;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedHospitalResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/selecte-hp")
+@RequiredArgsConstructor
+public class SelectedHospitalController {
+    private final SelectedHospitalService selectedHospitalService;
+
+    @Value("${app.name}")
+    private String appName;
+
+    //병원 선택 및 저장
+    @PostMapping("/{hospitalId}")
+    public ResponseEntity<SelectedHospitalResponseDTO> saveSelectedHospital(
+            @PathVariable Long hospitalId,
+            @AuthenticationPrincipal Member member
+    ) {
+        SelectedHospitalResponseDTO response = selectedHospitalService
+                .saveSelectedHospital(hospitalId, member, appName);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+
+    //특정 병원의 지도 URL 조회
+    @GetMapping("/{hospitalId}/maps")
+    public ResponseEntity<MapUrlResponseDTO> getMapUrlsForHospital(
+            @PathVariable Long hospitalId
+    ) {
+        MapUrlResponseDTO response = selectedHospitalService.getMapUrlsForHospital(hospitalId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedPharmacyController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedPharmacyController.java
@@ -1,0 +1,43 @@
+package com.mediko.mediko_server.domain.map.presentation;
+
+import com.mediko.mediko_server.domain.map.application.SelectedPharmacyService;
+import com.mediko.mediko_server.domain.map.dto.response.MapUrlResponseDTO;
+import com.mediko.mediko_server.domain.map.dto.response.SelectedPharmacyResponseDTO;
+import com.mediko.mediko_server.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/selecte-ph")
+@RequiredArgsConstructor
+public class SelectedPharmacyController {
+    private final SelectedPharmacyService selectedPharmacyService;
+
+    @Value("${app.name}")
+    private String appName;
+
+    //약국 선택 및 저장
+    @PostMapping("/{pharmacyId}")
+    public ResponseEntity<SelectedPharmacyResponseDTO> saveSelectedPharmacy(
+            @PathVariable Long pharmacyId,
+            @AuthenticationPrincipal Member member
+    ) {
+        SelectedPharmacyResponseDTO response = selectedPharmacyService
+                .saveSelectedPharmacy(pharmacyId, member, appName);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+    //약국의 지도 URL 조회
+    @GetMapping("/{pharmacyId}/maps")
+    public ResponseEntity<MapUrlResponseDTO> getMapUrlsForPharmacy(
+            @PathVariable Long pharmacyId
+    ) {
+        MapUrlResponseDTO response = selectedPharmacyService.getMapUrlsForPharmacy(pharmacyId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/HospitalService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/HospitalService.java
@@ -54,7 +54,7 @@ public class HospitalService {
         HealthInfo healthInfo = healthInfoRepository.findById(requestDTO.getHealthInfoId())
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "사용자의 건강정보가 존재하지 않습니다."));
 
-        // 2. 사용자 위치 처리 (latitude, longitude)
+        // 2. 사용자 위치 처리 (phLatitude, longitude)
         if (requestDTO.getUserLatitude() == null || requestDTO.getUserLongitude() == null) {
             throw new BadRequestException(INVALID_PARAMETER, "사용자의 위도와 경도 정보는 필수입니다.");
         }

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/PharmacyConverter.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/application/converter/PharmacyConverter.java
@@ -1,20 +1,10 @@
 package com.mediko.mediko_server.domain.recommend.application.converter;
 
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
-import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
-import com.mediko.mediko_server.domain.recommend.domain.Hospital;
 import com.mediko.mediko_server.domain.recommend.domain.Pharmacy;
-import com.mediko.mediko_server.domain.recommend.dto.request.HospitalRequestDTO;
 import com.mediko.mediko_server.domain.recommend.dto.request.PharmacyRequestDTO;
-import com.mediko.mediko_server.domain.recommend.dto.response.HospitalResponseDTO;
 import com.mediko.mediko_server.domain.recommend.dto.response.PharmacyResponseDTO;
-import com.mediko.mediko_server.domain.report.domain.Report;
 import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @Component
 public class PharmacyConverter {
@@ -27,8 +17,8 @@ public class PharmacyConverter {
                 .name(response.getName())
                 .address(response.getAddress())
                 .tel(response.getTel())
-                .latitude(response.getLatitude())
-                .longitude(response.getLongitude())
+                .phLatitude(response.getPhLatitude())
+                .phLongitude(response.getPhLongitude())
                 .start1(response.getStart1())
                 .start2(response.getStart2())
                 .start3(response.getStart3())

--- a/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Pharmacy.java
+++ b/src/main/java/com/mediko/mediko_server/domain/recommend/domain/Pharmacy.java
@@ -1,7 +1,6 @@
 package com.mediko.mediko_server.domain.recommend.domain;
 
 import com.mediko.mediko_server.domain.member.domain.BasicInfo;
-import com.mediko.mediko_server.domain.member.domain.Location;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -36,11 +35,11 @@ public class Pharmacy extends BaseEntity {
     @Column(name = "ph_tel")
     private String tel;
 
-    @Column(name = "hpLatitude")
-    private Double latitude;
+    @Column(name = "phLatitude")
+    private Double phLatitude;
 
-    @Column(name = "hpLongitude")
-    private Double longitude;
+    @Column(name = "phLongitude")
+    private Double phLongitude;
 
     @Column(name = "travle_km")
     private Double travelKm;
@@ -135,6 +134,6 @@ public class Pharmacy extends BaseEntity {
     private Member member;
 
     public List<Double> getLatLon() {
-        return Arrays.asList(longitude, latitude);
+        return Arrays.asList(phLatitude, phLongitude);
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #22 

### 🔑 주요 변경사항
- recommend된 병원, 약국, 응급실 리스트에서 사용자가 선택한 값을 저장하는 기능 구현
- 선택값을 저장할 때 map url이 같이 생성되도록 구현
- 네이버, 카카오, 구글 map url scheme 선택
- 장소 이름은 여러 개가 뜰 수 있으므로 좌표값(위도, 경도)로 검색
- 응급실의 경우 recommendResponse에서 좌표값이 따로 주어지지 않으므로 변환로직을 구현한다음 그 값을 받아오도록 수정 필요

