### PR TITLE
fix: openai api 전반적 통일

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/DetailedSignService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/DetailedSignService.java
@@ -24,7 +24,7 @@ public class DetailedSignService {
     private final DetailedSignRepository detailedSignRepository;
     private final SubBodyPartRepository subBodyPartRepository;
 
-    // 모든 DetailedSign 조회
+    // 상세 증상 전체 조회
     public List<DetailedSignResponseDTO> findAll() {
         List<DetailedSign> allDetailedSigns = detailedSignRepository.findAll();
         return allDetailedSigns.stream()
@@ -32,13 +32,11 @@ public class DetailedSignService {
                 .collect(Collectors.toList());
     }
 
-    // 주어진 SubBodyPart에 속하는 모든 DetailedSign 조회
+    // 상세 중상 부분 조회
     public List<DetailedSignResponseDTO> getDetailedSignsByBodyPart(String bodyPart) {
-        // 1. 입력받은 문자열과 일치하는 SubBodyPart 찾기
         SubBodyPart subBodyPart = subBodyPartRepository.findByBody(bodyPart)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "해당하는 신체 부위를 찾을 수 없습니다."));
 
-        // 2. 찾은 SubBodyPart에 해당하는 DetailedSign들 조회
         List<DetailedSign> detailedSigns = detailedSignRepository.findBySubBodyPart(subBodyPart);
 
         return detailedSigns.stream()

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/MainBodyPartService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/MainBodyPartService.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class MainBodyPartService {
     private final MainBodyPartRepository mainBodyPartRepository;
 
-    // 모든 MainBodyPart 조회
+    // 주요 신체 전체 조회
     public List<MainBodyPartResponseDTO> findAll() {
         List<MainBodyPart> allMainBodyParts = mainBodyPartRepository.findAll();
         return allMainBodyParts.stream()

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedMBPService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedMBPService.java
@@ -32,7 +32,7 @@ public class SelectedMBPService {
     private final MainBodyPartRepository mainBodyPartRepository;
 
 
-    // SelectedMBP 저장
+    // 선택한 주요 신체 저장
     @Transactional
     public SelectedMBPResponseDTO saveSelectedMBP(SelectedMBPRequestDTO requestDTO, Member member) {
         List<String> mainBodyPartNames = requestDTO.getBody();
@@ -66,7 +66,7 @@ public class SelectedMBPService {
     }
 
 
-    // SelectedMBP 조회
+    //선택한 주요 신체 조회
     public SelectedMBPResponseDTO getSelectedMBP(Long selectedMbpId, Member member) {
         SelectedMBP selectedMBP = selectedMBPRepository.findByIdAndMember(selectedMbpId, member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "선택된 신체 부분이 없습니다."));
@@ -75,7 +75,7 @@ public class SelectedMBPService {
     }
 
 
-    // SelectedMBP 수정
+    //선택한 주요 신체 수정
     @Transactional
     public SelectedMBPResponseDTO updateSelectedMBP(Long selectedMbpId, SelectedMBPRequestDTO requestDTO, Member member) {
         SelectedMBP selectedMBP = selectedMBPRepository.findById(selectedMbpId)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSBPService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSBPService.java
@@ -32,8 +32,11 @@ public class SelectedSBPService {
     private final SelectedMBPRepository selectedMBPRepository;
 
 
+    //선택한 세부 신체 저장
     @Transactional
-    public SelectedSBPResponseDTO saveSelectedSBP(Member member, SelectedSBPRequestDTO requestDTO, Long selectedMBPId) {
+    public SelectedSBPResponseDTO saveSelectedSBP(
+            Member member, SelectedSBPRequestDTO requestDTO, Long selectedMBPId
+    ) {
         List<SubBodyPart> validSubBodyParts = requestDTO.getBody().stream()
                 .map(body -> subBodyPartRepository.findByBody(body)
                         .orElseThrow(() -> new BadRequestException(INVALID_PARAMETER,
@@ -44,11 +47,9 @@ public class SelectedSBPService {
                 .map(SubBodyPart::getId)
                 .collect(Collectors.toList());
 
-        // 3. selectedMBPId로 선택된 SelectedMBP 찾기
         SelectedMBP selectedMBP = selectedMBPRepository.findById(selectedMBPId)
                 .orElseThrow(() -> new BadRequestException(INVALID_PARAMETER, "선택한 주신체 부분이 존재하지 않습니다."));
 
-        // 4. SelectedSBP 객체 생성
         SelectedSBP selectedSBP = requestDTO.toEntity()
                 .toBuilder()
                 .sbpIds(sbpIds)
@@ -56,16 +57,12 @@ public class SelectedSBPService {
                 .member(member)
                 .build();
 
-        // 5. SelectedSBP 저장
         selectedSBPRepository.save(selectedSBP);
 
-        // 6. Response DTO 반환
         return SelectedSBPResponseDTO.fromEntity(selectedSBP);
     }
 
-
-
-    // SelectedSBP 조회
+    //선택한 세부 신체 조회
     public SelectedSBPResponseDTO getSelectedSBP(Long selectedSBPId, Member member) {
         SelectedSBP selectedSBP = selectedSBPRepository.findByIdAndMember(selectedSBPId, member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "해당 세부 신체 부분을 찾을 수 없습니다."));
@@ -73,10 +70,11 @@ public class SelectedSBPService {
         return SelectedSBPResponseDTO.fromEntity(selectedSBP);
     }
 
-    // SelectedSBP 수정
+    //선택한 세부 신체 수정
     @Transactional
-    public SelectedSBPResponseDTO updateSelectedSBP(Long selectedSBPId, Member member, SelectedSBPRequestDTO requestDTO) {
-        // 요청받은 body part들을 검증
+    public SelectedSBPResponseDTO updateSelectedSBP(
+            Long selectedSBPId, Member member, SelectedSBPRequestDTO requestDTO
+    ) {
         List<SubBodyPart> validSubBodyParts = requestDTO.getBody().stream()
                 .map(body -> subBodyPartRepository.findByBody(body)
                         .orElseThrow(() -> new BadRequestException(INVALID_PARAMETER,
@@ -87,17 +85,12 @@ public class SelectedSBPService {
                 .map(SubBodyPart::getId)
                 .collect(Collectors.toList());
 
-        // 기존에 저장된 SelectedSBP를 가져옴
         SelectedSBP selectedSBP = selectedSBPRepository.findByIdAndMember(selectedSBPId, member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "해당 세부 신체 부분을 찾을 수 없습니다."));
 
-        // 기존 SelectedSBP에서 연결된 SelectedMBP 사용
-        SelectedMBP selectedMBP = selectedSBP.getSelectedMBP(); // 이미 연결된 SelectedMBP 사용
-
-        // SelectedSBP 수정
+        SelectedMBP selectedMBP = selectedSBP.getSelectedMBP();
         selectedSBP.updateSelectedSBP(requestDTO, sbpIds, selectedMBP);
 
-        // 변경된 SelectedSBP 저장
         selectedSBPRepository.save(selectedSBP);
 
         return SelectedSBPResponseDTO.fromEntity(selectedSBP);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SubBodyPartService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SubBodyPartService.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class SubBodyPartService {
     private final SubBodyPartRepository subBodyPartRepository;
 
-    // 모든 SubBodyPart 조회
+    // 세부 신체 전체 조회
     public List<SubBodyPartResponseDTO> findAll() {
         List<SubBodyPart> allSubBodyParts = subBodyPartRepository.findAll();
         return allSubBodyParts.stream()
@@ -26,8 +26,7 @@ public class SubBodyPartService {
                 .collect(Collectors.toList());
     }
 
-    // MainBodyPart에 속하는 SubBodyPart 모두 조회
-    @Transactional
+    // 세부 신체 부분 조회
     public List<SubBodyPart> getSubBodyPartsByMainBodyPartBodies(List<String> bodies) {
         return subBodyPartRepository.findAllByMainBodyPartBodies(bodies);
     }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SymptomService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SymptomService.java
@@ -67,26 +67,22 @@ public class SymptomService {
 
     // 증상 시작시간 조회
     public PainStartResponseDTO getPainStart(Long symptomId, Member member) {
-        Symptom symptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+
         return PainStartResponseDTO.fromEntity(symptom);
     }
 
     // 증상 시작시간 수정
     @Transactional
     public PainStartResponseDTO updatePainStart(Long symptomId, PainStartRequestDTO requestDTO, Member member) {
-
         validateTimeValue(requestDTO.getStartValue(), requestDTO.getStartUnit());
 
-        Symptom existingSymptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+        symptom.updatePainStart(requestDTO.getStartValue(), requestDTO.getStartUnit());
 
-        existingSymptom.updatePainStart(requestDTO.getStartValue(), requestDTO.getStartUnit());
-
-        Symptom savedSymptom = symptomRepository.save(existingSymptom);
-
-        return PainStartResponseDTO.fromEntity(savedSymptom);
+        return PainStartResponseDTO.fromEntity(symptom);
     }
+
 
     /**
      * Intensity 관련 메서드
@@ -94,23 +90,29 @@ public class SymptomService {
     //증상 강도 저장
     @Transactional
     public IntensityResponseDTO saveIntensity(Long symptomId, IntensityRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
 
-        Symptom existingSymptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        validatePainStartExists(symptom);
+        symptom.updateIntensity(requestDTO.getIntensity());
 
-        validatePainStartExists(existingSymptom);
-
-        existingSymptom.updateIntensity(requestDTO.getIntensity());
-
-        Symptom savedSymptom = symptomRepository.save(existingSymptom);
-
-        return IntensityResponseDTO.fromEntity(savedSymptom);
+        return IntensityResponseDTO.fromEntity(symptom);
     }
 
     //증상 강도 조회
     public IntensityResponseDTO getIntensity(Long symptomId, Member member) {
-        Symptom symptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+
+        return IntensityResponseDTO.fromEntity(symptom);
+    }
+
+    //증상 강도 수정
+    @Transactional
+    public IntensityResponseDTO updateIntensity(Long symptomId, IntensityRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+
+        validatePainStartExists(symptom);
+        symptom.updateIntensity(requestDTO.getIntensity());
+
         return IntensityResponseDTO.fromEntity(symptom);
     }
 
@@ -121,29 +123,34 @@ public class SymptomService {
     //증상 지속기간 저장
     @Transactional
     public DurationResponseDTO saveDuration(Long symptomId, DurationRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
 
-        Symptom existingSymptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
-
-        validateIntensityExists(existingSymptom);
-
+        validateIntensityExists(symptom);
         validateTimeValue(requestDTO.getDurationValue(), requestDTO.getDurationUnit());
 
-        existingSymptom.updateDuration(requestDTO.getDurationValue(), requestDTO.getDurationUnit());
+        symptom.updateDuration(requestDTO.getDurationValue(), requestDTO.getDurationUnit());
 
-        Symptom savedSymptom = symptomRepository.save(existingSymptom);
-
-        return DurationResponseDTO.fromEntity(savedSymptom);
+        return DurationResponseDTO.fromEntity(symptom);
     }
 
     //증상 지속기간 조회
     public DurationResponseDTO getDuration(Long symptomId, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
 
-        Symptom symptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
         return DurationResponseDTO.fromEntity(symptom);
     }
 
+    @Transactional
+    public DurationResponseDTO updateDuration(Long symptomId, DurationRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+
+        validateIntensityExists(symptom);
+        validateTimeValue(requestDTO.getDurationValue(), requestDTO.getDurationUnit());
+
+        symptom.updateDuration(requestDTO.getDurationValue(), requestDTO.getDurationUnit());
+
+        return DurationResponseDTO.fromEntity(symptom);
+    }
 
 
     /**
@@ -152,60 +159,74 @@ public class SymptomService {
     //증상 추가정보 저장
     @Transactional
     public AdditionalInfoResponseDTO saveAdditionalInfo(Long symptomId, AdditionalInfoRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
 
-        Symptom existingSymptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        validateDurationExists(symptom);
+        symptom.updateAdditionalInfo(requestDTO.getAdditional());
 
-        validateDurationExists(existingSymptom);
-
-        existingSymptom.updateAdditionalInfo(requestDTO.getAdditional());
-        Symptom savedSymptom = symptomRepository.save(existingSymptom);
-
-        return AdditionalInfoResponseDTO.fromEntity(savedSymptom);
+        return AdditionalInfoResponseDTO.fromEntity(symptom);
     }
 
-
-    //증상 추가 정보 조회
+    //증상 추가정보 조회
     public AdditionalInfoResponseDTO getAdditionalInfo(Long symptomId, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
 
-        Symptom symptom = symptomRepository.findByIdAndMemberId(symptomId, member.getId())
-                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
+        return AdditionalInfoResponseDTO.fromEntity(symptom);
+    }
+
+    //증상 추가정보 수정
+    @Transactional
+    public AdditionalInfoResponseDTO updateAdditionalInfo(Long symptomId, AdditionalInfoRequestDTO requestDTO, Member member) {
+        Symptom symptom = findSymptomByIdAndMember(symptomId, member);
+
+        validateDurationExists(symptom);
+        symptom.updateAdditionalInfo(requestDTO.getAdditional());
+
         return AdditionalInfoResponseDTO.fromEntity(symptom);
     }
 
 
     /**
-     * TimeValue + TimeUnit 값 검증
+     * 저장된 증상정보가 있는지 확인
      */
-
-    private void validateTimeValue(int value, TimeUnit timeUnit) {
-        if (!timeUnit.isValidValue(value)) {
-            throw new BadRequestException(INVALID_FORMAT, value + "값 은 " + timeUnit + " 단위에 유효하지 않습니다.");
-        }
+    private Symptom findSymptomByIdAndMember(Long symptomId, Member member) {
+        return symptomRepository.findByIdAndMemberId(symptomId, member.getId())
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "저장된 증상정보를 찾을 수 없습니다."));
     }
 
+    /**
+     * TimeValue + TimeUnit 값 검증
+     */
+    private void validateTimeValue(int value, TimeUnit timeUnit) {
+        if (!timeUnit.isValidValue(value)) {
+            throw new BadRequestException(INVALID_FORMAT,
+                    value + "값 은 " + timeUnit + " 단위에 유효하지 않습니다.");
+        }
+    }
 
     /**
      * 이전 단계 데이터 존재 여부 검증
      */
-
     private void validatePainStartExists(Symptom symptom) {
         if (symptom.getStartValue() == 0 || symptom.getStartUnit() == TimeUnit.DEFAULT) {
-            throw new BadRequestException(MISSING_REQUIRED_FIELD, "통증 시작시간 정보가 없습니다. 먼저 통증 시작시간 정보를 입력해주세요.");
+            throw new BadRequestException(MISSING_REQUIRED_FIELD,
+                    "통증 시작시간 정보가 없습니다. 먼저 통증 시작시간 정보를 입력해주세요.");
         }
     }
 
     private void validateIntensityExists(Symptom symptom) {
         validatePainStartExists(symptom);
         if (symptom.getIntensity() == 0) {
-            throw new BadRequestException(MISSING_REQUIRED_FIELD, "통증 강도 정보가 없습니다. 먼저 통증 강도 정보를 입력해주세요.");
+            throw new BadRequestException(MISSING_REQUIRED_FIELD,
+                    "통증 강도 정보가 없습니다. 먼저 통증 강도 정보를 입력해주세요.");
         }
     }
 
     private void validateDurationExists(Symptom symptom) {
         validateIntensityExists(symptom);
         if (symptom.getDurationValue() == 0 || symptom.getDurationUnit() == TimeUnit.DEFAULT) {
-            throw new BadRequestException(MISSING_REQUIRED_FIELD, "통증 지속기간 정보가 없습니다. 먼저 통증 지속기간 정보를 입력해주세요.");
+            throw new BadRequestException(MISSING_REQUIRED_FIELD,
+                    "통증 지속기간 정보가 없습니다. 먼저 통증 지속기간 정보를 입력해주세요.");
         }
     }
 

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/MainBodyPart.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/MainBodyPart.java
@@ -1,6 +1,5 @@
 package com.mediko.mediko_server.domain.openai.domain;
 
-import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -14,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name= "mainBodyPart")
+@Table(name= "main_body_part")
 public class MainBodyPart extends BaseEntity {
 
     @Column(nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedMBP.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedMBP.java
@@ -2,7 +2,6 @@ package com.mediko.mediko_server.domain.openai.domain;
 
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.dto.request.SelectedMBPRequestDTO;
-import com.mediko.mediko_server.domain.openai.dto.request.SelectedSBPRequestDTO;
 import com.mediko.mediko_server.global.converter.LongListConverter;
 import com.mediko.mediko_server.global.converter.StringListConvert;
 import com.mediko.mediko_server.global.domain.BaseEntity;
@@ -11,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name= "selectedMbp")
+@Table(name= "selected_mbp")
 public class SelectedMBP extends BaseEntity {
     @Convert(converter = StringListConvert.class)
     @Column(nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedSBP.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/SelectedSBP.java
@@ -19,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name= "selectedSbp")
+@Table(name= "selected_sbp")
 public class SelectedSBP extends BaseEntity {
     @Convert(converter = StringListConvert.class)
     @Column(nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/SubBodyPart.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/SubBodyPart.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name= "subBodyPart")
+@Table(name= "sub_body_part")
 public class SubBodyPart extends BaseEntity {
     @Column(nullable = false)
     private String body;

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/DetailedSignRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/DetailedSignRepository.java
@@ -1,20 +1,13 @@
 package com.mediko.mediko_server.domain.openai.domain.repository;
 
-import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.domain.DetailedSign;
-import com.mediko.mediko_server.domain.openai.domain.SelectedMBP;
-import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
 import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.http.StreamingHttpOutputMessage;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface DetailedSignRepository extends JpaRepository<DetailedSign, Long> {
-    //주어진 SubBodyPart에 속한 모든 DetailedSign을 조회
+
     List<DetailedSign> findBySubBodyPart(SubBodyPart subBodyPart);
 
     List<DetailedSign> findBySubBodyPartIdIn(List<Long> subBodyPartIds);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/MainBodyPartRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/MainBodyPartRepository.java
@@ -4,9 +4,9 @@ import com.mediko.mediko_server.domain.openai.domain.MainBodyPart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 
 public interface MainBodyPartRepository extends JpaRepository<MainBodyPart, Long> {
+
     List<MainBodyPart> findByBodyIn(List<String> bodies);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedMBPRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedMBPRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 
 public interface SelectedMBPRepository extends JpaRepository<SelectedMBP, Long> {
+
     Optional<SelectedMBP> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSBPRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSBPRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SelectedSBPRepository extends JpaRepository<SelectedSBP, Long> {
+
     Optional<SelectedSBP> findByIdAndMember(Long selectedSbpId, Member member);
 
     List<SelectedSBP> findBySelectedMBPAndMember(SelectedMBP selectedMBP, Member member);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSignRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SelectedSignRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface SelectedSignRepository extends JpaRepository<SelectedSign, Long> {
+
     Optional<SelectedSign> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SubBodyPartRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SubBodyPartRepository.java
@@ -1,7 +1,5 @@
 package com.mediko.mediko_server.domain.openai.domain.repository;
 
-import com.mediko.mediko_server.domain.openai.domain.MainBodyPart;
-import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
 import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,10 +10,9 @@ import java.util.Optional;
 
 
 public interface SubBodyPartRepository extends JpaRepository<SubBodyPart, Long> {
-    //주어진 MainBodyPart에 속한 모든 SubBodyPart 조회
+
     @Query("SELECT sbp FROM SubBodyPart sbp JOIN sbp.mainBodyPart mbp WHERE mbp.body IN :bodies")
     List<SubBodyPart> findAllByMainBodyPartBodies(@Param("bodies") List<String> bodies);
 
-    // 주어진 body와 일치하는 SubBodyPart 조히
     Optional<SubBodyPart> findByBody(String body);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SymptomRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/repository/SymptomRepository.java
@@ -1,12 +1,11 @@
 package com.mediko.mediko_server.domain.openai.domain.repository;
 
-import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
 import com.mediko.mediko_server.domain.openai.domain.Symptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface SymptomRepository  extends JpaRepository<Symptom, Long> {
-    // Member와 관련된 symptom을 찾아주는 메서드
+
     Optional<Symptom> findByIdAndMemberId(Long symptomId, Long memberId);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
@@ -12,18 +12,12 @@ public class SelectedMBPResponseDTO {
 
     private List<String> body;
 
-    private List<Long> mbpIds;
-
     private Long selectedMBPId;
-
-    private Long memberId;
 
     public static SelectedMBPResponseDTO fromEntity(SelectedMBP selectedMBP) {
         return new SelectedMBPResponseDTO(
                 selectedMBP.getBody(),
-                selectedMBP.getMbpIds(),
-                selectedMBP.getId(),
-                selectedMBP.getMember().getId()
+                selectedMBP.getId()
         );
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
@@ -12,21 +12,15 @@ public class SelectedSBPResponseDTO {
 
     private List<String> body;
 
-    private List<Long> sbpIds;
-
     private Long selectedSBPId;
 
     private Long selectedMBPId;
 
-    private Long memberId;
-
     public static SelectedSBPResponseDTO fromEntity(SelectedSBP selectedSBP) {
         return new SelectedSBPResponseDTO(
                 selectedSBP.getBody(),
-                selectedSBP.getSbpIds(),
                 selectedSBP.getId(),
-                selectedSBP.getSelectedMBP().getId(),
-                selectedSBP.getMember().getId()
+                selectedSBP.getSelectedMBP().getId()
         );
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSignResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSignResponseDTO.java
@@ -16,14 +16,13 @@ public class SelectedSignResponseDTO {
 
     private Long signId;
 
-    private List<Long> sbpId;
+    private Long selectedSBPId;
 
-    public static SelectedSignResponseDTO fromEntity(
-            SelectedSign selectedSign, SelectedSBP selectedSBP) {
+    public static SelectedSignResponseDTO fromEntity(SelectedSign selectedSign) {
         return new SelectedSignResponseDTO(
                 selectedSign.getSign(),
                 selectedSign.getId(),
-                selectedSBP.getSbpIds()
+                selectedSign.getSelectedSBP().getId()
         );
     }
 

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DetailedSignController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DetailedSignController.java
@@ -2,6 +2,8 @@ package com.mediko.mediko_server.domain.openai.presentation;
 
 import com.mediko.mediko_server.domain.openai.application.DetailedSignService;
 import com.mediko.mediko_server.domain.openai.dto.response.DetailedSignResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "detailed sign", description = "상세 증상 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -18,16 +21,16 @@ import java.util.List;
 public class DetailedSignController {
     private final DetailedSignService detailedSignService;
 
-    // 모든 DetailedSign 조회
+    @Operation(summary = "상세 증상 전체 조회", description = "모든 상세 증상을 조회합니다.")
     @GetMapping("/all")
     public List<DetailedSignResponseDTO> getAllDetailedSigns() {
         return detailedSignService.findAll();
     }
 
-    // 특정 SubBodyPart에 속하는 DetailedSign 조회
+    @Operation(summary = "상세 중상 부분 조회", description = "선택된 세부 신체에 포함된 모든 상세 증상을 조회합니다.")
     @GetMapping
     public List<DetailedSignResponseDTO> getDetailedSignsBySubBodyPart(
-            @RequestParam("body") String body) {
+            @RequestParam(name = "body") String body) {
         return detailedSignService.getDetailedSignsByBodyPart(body);
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/MainBodyPartController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/MainBodyPartController.java
@@ -3,6 +3,8 @@ package com.mediko.mediko_server.domain.openai.presentation;
 
 import com.mediko.mediko_server.domain.openai.application.MainBodyPartService;
 import com.mediko.mediko_server.domain.openai.dto.response.MainBodyPartResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +14,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "main body", description = "주요 신체 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/main-body-part")
+@RequestMapping("/api/v1/main-body")
 public class MainBodyPartController {
     private final MainBodyPartService mainBodyPartService;
 
-    // 모든 주신체 부분 조회
-    @GetMapping()
+    @Operation(summary = "주요 신체 전체 조회", description = "모든 주요 신체룰 조회합니다.")
+    @GetMapping("/all")
     public ResponseEntity<List<MainBodyPartResponseDTO>> findAll() {
         List<MainBodyPartResponseDTO> mainBodyParts = mainBodyPartService.findAll();
         return ResponseEntity.ok(mainBodyParts);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedMBPController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedMBPController.java
@@ -5,12 +5,15 @@ import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.application.SelectedMBPService;
 import com.mediko.mediko_server.domain.openai.dto.request.SelectedMBPRequestDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.SelectedMBPResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "main body", description = "주요 신체 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class SelectedMBPController {
     private final SelectedMBPService selectedMBPService;
 
-    // 선택된 주신체 부분 저장
+    @Operation(summary = "선택한 주요 신체 저장", description = "사용자가 선택한 주요 신체를 저장합니다.")
     @PostMapping
     public ResponseEntity<SelectedMBPResponseDTO> selectMainBodyPart(
             @RequestBody SelectedMBPRequestDTO requestDTO,
@@ -29,7 +32,7 @@ public class SelectedMBPController {
         return ResponseEntity.ok(responseDTO);
     }
 
-    // 특정 selectedMBP 조회
+    @Operation(summary = "선택한 주요 신체 조회", description = "선택된 주요 신체를 조회합니다.")
     @GetMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedMBPResponseDTO> getSelectedMBP(
             @PathVariable("selectedMBPId") Long selectedMBPId,
@@ -41,7 +44,7 @@ public class SelectedMBPController {
     }
 
 
-    // 특정 주신체 부분 수정
+    @Operation(summary = "선택한 주요 신체 수정", description = "선택된 주요 신체를 수정합니다.")
     @PutMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedMBPResponseDTO> updateSelectedMBP(
             @PathVariable("selectedMBPId") Long selectedMBPId,
@@ -52,6 +55,4 @@ public class SelectedMBPController {
         SelectedMBPResponseDTO responseDTO = selectedMBPService.updateSelectedMBP(selectedMBPId, requestDTO, member);
         return ResponseEntity.ok(responseDTO);
     }
-
-
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSBPController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSBPController.java
@@ -5,6 +5,8 @@ import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.openai.application.SelectedSBPService;
 import com.mediko.mediko_server.domain.openai.dto.request.SelectedSBPRequestDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.SelectedSBPResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-
+@Tag(name = "sub body", description = "세부 신체 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -20,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class SelectedSBPController {
     private final SelectedSBPService selectedSBPService;
 
-    //선택된 세부신체 부분 저장
+    @Operation(summary = "선택한 세부 신체 저장", description = "사용자가 선택한 세부 신체를 저장합니다.")
     @PostMapping("/{selectedMBPId}")
     public ResponseEntity<SelectedSBPResponseDTO> saveSelectedSBP(
             @PathVariable("selectedMBPId") Long selectedMBPId,
@@ -32,8 +34,7 @@ public class SelectedSBPController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
     }
 
-
-    // 특정 세부신체 부분 조회
+    @Operation(summary = "선택한 세부 신체 조회", description = "선택된 세부 신체를 조회합니다.")
     @GetMapping("/{selectedSBPId}")
     public ResponseEntity<SelectedSBPResponseDTO> getSelectedSBP(
             @PathVariable("selectedSBPId") Long selectedSBPId,
@@ -44,7 +45,7 @@ public class SelectedSBPController {
         return ResponseEntity.ok(responseDTO);
     }
 
-    // 특정 세부신체 부분 수정
+    @Operation(summary = "선택한 세부 신체 수정", description = "선택된 세부 신체를 수정합니다.")
     @PutMapping("/{selectedSBPId}")
     public ResponseEntity<SelectedSBPResponseDTO> updateSelectedSBP(
             @PathVariable("selectedSBPId") Long selectedSBPId,

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSignController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSignController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Selected Sign API", description = "선택된 상세 증상 관련 API")
+@Tag(name = "detailed sign", description = "상세 증상 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/selected-sign")
@@ -20,7 +20,7 @@ public class SelectedSignController {
 
     private final SelectedSignService selectedSignService;
 
-    @Operation(summary = "상세 증상 저장", description = "선택된 세부 신체 부위에 대한 상세 증상을 저장합니다.")
+    @Operation(summary = "선택한 상세 증상 저장", description = "사용자가 선택한 상세 증상을 저장합니다.")
     @PostMapping("/{selectedSBPId}")
     public ResponseEntity<SelectedSignResponseDTO> saveSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,
@@ -34,7 +34,7 @@ public class SelectedSignController {
         return ResponseEntity.ok(responseDTO);
     }
 
-    @Operation(summary = "선택된 상세 증상 조회", description = "특정 ID의 선택된 상세 증상 정보를 조회합니다.")
+    @Operation(summary = "선택한 상세 증상 조회", description = "선택된 상세 증상을 조회합니다.")
     @GetMapping("/{selectedSignId}")
     public ResponseEntity<SelectedSignResponseDTO> getSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,
@@ -46,7 +46,7 @@ public class SelectedSignController {
         return ResponseEntity.ok(responseDTO);
     }
 
-    @Operation(summary = "선택된 상세 증상 수정", description = "특정 ID의 선택된 상세 증상 정보를 수정합니다.")
+    @Operation(summary = "선택한 상세 증상 수정", description = "선택된 상세 증상을 수정합니다.")
     @PutMapping("/{selectedSignId}")
     public ResponseEntity<SelectedSignResponseDTO> updateSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
@@ -4,6 +4,8 @@ import com.mediko.mediko_server.domain.openai.application.SubBodyPartService;
 import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
 import com.mediko.mediko_server.domain.openai.dto.request.SelectedSBPRequestDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.SubBodyPartResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,26 +14,27 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Tag(name = "sub body", description = "세부 신체 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/sub-body-part")
+@RequestMapping("/api/v1/sub-body")
 public class SubBodyPartController {
     private final SubBodyPartService subBodyPartService;
 
-    // 모든 세부신체 부분 조회
-    @GetMapping()
+    @Operation(summary = "세부 신체 전체 조회", description = "모든 세부 신체를 조회합니다.")
+    @GetMapping("/all")
     public ResponseEntity<List<SubBodyPartResponseDTO>> findAll() {
         List<SubBodyPartResponseDTO> subBodyParts = subBodyPartService.findAll();
         return ResponseEntity.ok(subBodyParts);
     }
 
-    //선택된 주신체 부분에 포함된 모든 세부신체 부분 조회
-    @PostMapping
+    @Operation(summary = "세부 신체 부분 조회", description = "선택된 주요 신체에 포함된 모든 세부 신체를 조회합니다.")
+    @GetMapping
     public ResponseEntity<List<SubBodyPartResponseDTO>> getSubBodyPartsByBodies(
-            @RequestBody SelectedSBPRequestDTO requestBody
+            @RequestParam(name = "body") List<String> body
     ) {
-        List<SubBodyPart> subBodyParts = subBodyPartService.getSubBodyPartsByMainBodyPartBodies(requestBody.getBody());
+        List<SubBodyPart> subBodyParts = subBodyPartService.getSubBodyPartsByMainBodyPartBodies(body);
         List<SubBodyPartResponseDTO> response = subBodyParts.stream()
                 .map(SubBodyPartResponseDTO::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SymptomController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SymptomController.java
@@ -11,6 +11,8 @@ import com.mediko.mediko_server.domain.openai.dto.response.DurationResponseDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.IntensityResponseDTO;
 import com.mediko.mediko_server.domain.openai.dto.response.PainStartResponseDTO;
 import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Tag(name = "symptom", description = "증상 강도 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +36,7 @@ public class SymptomController {
     /**
      * PainStart 관련 메서드
      */
+    @Operation(summary = "증상 시작시간 저장", description = "증상이 시작된 시간을 저장합니다.")
     @PostMapping("/start/{selectedSBPIds}")
     public ResponseEntity<PainStartResponseDTO> savePainStart(
             @PathVariable("selectedSBPIds") String selectedSBPIds,
@@ -49,6 +53,7 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 시작시간 조회", description = "저장된 증상 시작시간을 조회합니다.")
     @GetMapping("/start/{symptomId}")
     public ResponseEntity<PainStartResponseDTO> getPainStart(
             @PathVariable("symptomId") Long symptomId,
@@ -59,6 +64,7 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 시작시간 수정", description = "저장된 증상 시작시간을 수정합니다.")
     @PutMapping("/start/{symptomId}")
     public ResponseEntity<PainStartResponseDTO> updatePainStart(
             @PathVariable("symptomId") Long symptomId,
@@ -74,7 +80,8 @@ public class SymptomController {
     /**
      * Intensity 관련 메서드
      */
-    @PutMapping("/intensity/{symptomId}")
+    @Operation(summary = "증상 강도 저장", description = "증상의 강도를 저장합니다.")
+    @PostMapping("/intensity/{symptomId}")
     public ResponseEntity<IntensityResponseDTO> saveIntensity(
             @PathVariable("symptomId") Long symptomId,
             @Valid @RequestBody IntensityRequestDTO requestDTO,
@@ -85,6 +92,8 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+
+    @Operation(summary = "증상 강도 조회", description = "저장된 증상의 강도를 조회합니다.")
     @GetMapping("/intensity/{symptomId}")
     public ResponseEntity<IntensityResponseDTO> getIntensity(
             @PathVariable("symptomId") Long symptomId,
@@ -95,10 +104,23 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 강도 수정", description = "저장된 중상의 강도를 수정합니다.")
+    @PutMapping("/intensity/{symptomId}")
+    public ResponseEntity<IntensityResponseDTO> updateIntensity(
+            @PathVariable("symptomId") Long symptomId,
+            @Valid @RequestBody IntensityRequestDTO requestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Member member = userDetails.getMember();
+        IntensityResponseDTO response = symptomService.updateIntensity(symptomId, requestDTO, member);
+        return ResponseEntity.ok(response);
+    }
+
     /**
      * Duration 관련 메서드
      */
-    @PutMapping("/duration/{symptomId}")
+    @Operation(summary = "증상 지속기간 저장", description = "증상의 지속기간을 저장힙니다.")
+    @PostMapping("/duration/{symptomId}")
     public ResponseEntity<DurationResponseDTO> saveDuration(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody DurationRequestDTO requestDTO,
@@ -109,6 +131,7 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 지속기간 조회", description = "저장된 증상의 지속기간을 조회합니다.")
     @GetMapping("/duration/{symptomId}")
     public ResponseEntity<DurationResponseDTO> getDuration(
             @PathVariable("symptomId") Long symptomId,
@@ -119,11 +142,24 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 지속기간 수정", description = "저장된 증상의 지속기간을 수정합니다.")
+    @PutMapping("/duration/{symptomId}")
+    public ResponseEntity<DurationResponseDTO> updateDuration(
+            @PathVariable("symptomId") Long symptomId,
+            @RequestBody DurationRequestDTO requestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Member member = userDetails.getMember();
+        DurationResponseDTO response = symptomService.updateDuration(symptomId, requestDTO, member);
+        return ResponseEntity.ok(response);
+    }
+
 
     /**
      * AdditionalInfo 관련 메서드
      */
-    @PutMapping("/additional/{symptomId}")
+    @Operation(summary = "증상 추가정보 저장", description = "증상의 추가정보를 저장합니다.")
+    @PostMapping("/additional/{symptomId}")
     public ResponseEntity<AdditionalInfoResponseDTO> saveAdditionalInfo(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody AdditionalInfoRequestDTO requestDTO,
@@ -134,6 +170,7 @@ public class SymptomController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "증상 추가정보 조회", description = "저장된 증상의 추가정보를 조회합니다.")
     @GetMapping("/additional/{symptomId}")
     public ResponseEntity<AdditionalInfoResponseDTO> getAdditionalInfo(
             @PathVariable("symptomId") Long symptomId,
@@ -141,6 +178,18 @@ public class SymptomController {
     ) {
         Member member = userDetails.getMember();
         AdditionalInfoResponseDTO response = symptomService.getAdditionalInfo(symptomId, member);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "증상 추가정보 수정", description = "증상의 추가정보를 수정합니다.")
+    @PutMapping("/additional/{symptomId}")
+    public ResponseEntity<AdditionalInfoResponseDTO> updateAdditionalInfo(
+            @PathVariable("symptomId") Long symptomId,
+            @RequestBody AdditionalInfoRequestDTO requestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Member member = userDetails.getMember();
+        AdditionalInfoResponseDTO response = symptomService.updateAdditionalInfo(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- symptom에서 각 증상 생성 메서드 추가
- subBodyPart의 부분조회 메서드를 post/RequestBody 사용방식에서 get/RequestParam 방식으로 변경
- mainBodyPart, subBodyPart, DetailedSign 컨트롤러 앤드포인트 통일
- selectedMBP의 responseDTO에서 memberId, mbpId 제외
- selectedSBP의 responseDTO에서 memberId, sbpId 제외
- detailedSign의 responseDTO에서 sbpId를 selectedSBPId로 변경
- 각 컨트롤러에 swagger 어노테이션을 사용해서 기능 설명

