### PR TITLE
feat: report mapper 생성

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedMBPService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedMBPService.java
@@ -31,7 +31,6 @@ public class SelectedMBPService {
     private final SelectedSBPRepository selectedSBPRepository;
     private final MainBodyPartRepository mainBodyPartRepository;
 
-
     // 선택한 주요 신체 저장
     @Transactional
     public SelectedMBPResponseDTO saveSelectedMBP(SelectedMBPRequestDTO requestDTO, Member member) {
@@ -62,18 +61,16 @@ public class SelectedMBPService {
 
         selectedMBP = selectedMBPRepository.save(selectedMBP);
 
-        return SelectedMBPResponseDTO.fromEntity(selectedMBP);
+        return SelectedMBPResponseDTO.fromEntity(selectedMBP, mainBodyPartRepository);
     }
-
 
     //선택한 주요 신체 조회
     public SelectedMBPResponseDTO getSelectedMBP(Long selectedMbpId, Member member) {
         SelectedMBP selectedMBP = selectedMBPRepository.findByIdAndMember(selectedMbpId, member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "선택된 신체 부분이 없습니다."));
 
-        return SelectedMBPResponseDTO.fromEntity(selectedMBP);
+        return SelectedMBPResponseDTO.fromEntity(selectedMBP, mainBodyPartRepository);
     }
-
 
     //선택한 주요 신체 수정
     @Transactional
@@ -91,11 +88,13 @@ public class SelectedMBPService {
             selectedSBPRepository.deleteAll(selectedSBPs);
         }
 
-        selectedMBP.updateSelectedMBP(requestDTO, mainBodyParts.stream()
+        List<Long> mbpIds = mainBodyParts.stream()
                 .map(MainBodyPart::getId)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        selectedMBP.updateSelectedMBP(requestDTO, mbpIds);
         selectedMBPRepository.save(selectedMBP);
 
-        return SelectedMBPResponseDTO.fromEntity(selectedMBP);
+        return SelectedMBPResponseDTO.fromEntity(selectedMBP, mainBodyPartRepository);
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSBPService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSBPService.java
@@ -31,8 +31,7 @@ public class SelectedSBPService {
     private final SubBodyPartRepository subBodyPartRepository;
     private final SelectedMBPRepository selectedMBPRepository;
 
-
-    //선택한 세부 신체 저장
+    // 선택한 세부 신체 저장
     @Transactional
     public SelectedSBPResponseDTO saveSelectedSBP(
             Member member, SelectedSBPRequestDTO requestDTO, Long selectedMBPId
@@ -59,18 +58,18 @@ public class SelectedSBPService {
 
         selectedSBPRepository.save(selectedSBP);
 
-        return SelectedSBPResponseDTO.fromEntity(selectedSBP);
+        return SelectedSBPResponseDTO.fromEntity(selectedSBP, subBodyPartRepository);
     }
 
-    //선택한 세부 신체 조회
+    // 선택한 세부 신체 조회
     public SelectedSBPResponseDTO getSelectedSBP(Long selectedSBPId, Member member) {
         SelectedSBP selectedSBP = selectedSBPRepository.findByIdAndMember(selectedSBPId, member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "해당 세부 신체 부분을 찾을 수 없습니다."));
 
-        return SelectedSBPResponseDTO.fromEntity(selectedSBP);
+        return SelectedSBPResponseDTO.fromEntity(selectedSBP, subBodyPartRepository);
     }
 
-    //선택한 세부 신체 수정
+    // 선택한 세부 신체 수정
     @Transactional
     public SelectedSBPResponseDTO updateSelectedSBP(
             Long selectedSBPId, Member member, SelectedSBPRequestDTO requestDTO
@@ -93,7 +92,6 @@ public class SelectedSBPService {
 
         selectedSBPRepository.save(selectedSBP);
 
-        return SelectedSBPResponseDTO.fromEntity(selectedSBP);
+        return SelectedSBPResponseDTO.fromEntity(selectedSBP, subBodyPartRepository);
     }
-
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/Symptom.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/Symptom.java
@@ -53,6 +53,9 @@ public class Symptom extends BaseEntity {
     @OneToMany(mappedBy = "symptom", cascade = CascadeType.ALL)
     private List<SelectedSign> selectedSigns = new ArrayList<>();
 
+    @OneToMany(mappedBy = "symptom", fetch = FetchType.LAZY)
+    private List<UuidFile> uuidFiles = new ArrayList<>();
+
     // selectedDetailedSign의 sign을 가져오는 메서드
     public List<String> getSelectedSigns() {
         return selectedSigns.stream()

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedMBPResponseDTO.java
@@ -1,22 +1,32 @@
 package com.mediko.mediko_server.domain.openai.dto.response;
 
+import com.mediko.mediko_server.domain.openai.domain.MainBodyPart;
 import com.mediko.mediko_server.domain.openai.domain.SelectedMBP;
+import com.mediko.mediko_server.domain.openai.domain.repository.MainBodyPartRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 public class SelectedMBPResponseDTO {
 
-    private List<String> body;
+    private List<String> description;
 
     private Long selectedMBPId;
 
-    public static SelectedMBPResponseDTO fromEntity(SelectedMBP selectedMBP) {
+    public static SelectedMBPResponseDTO fromEntity(
+            SelectedMBP selectedMBP, MainBodyPartRepository mainBodyPartRepository) {
+        List<MainBodyPart> mainBodyParts = mainBodyPartRepository.findAllById(selectedMBP.getMbpIds());
+
+        List<String> description = mainBodyParts.stream()
+                .map(MainBodyPart::getDescription)
+                .collect(Collectors.toList());
+
         return new SelectedMBPResponseDTO(
-                selectedMBP.getBody(),
+                description,
                 selectedMBP.getId()
         );
     }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSBPResponseDTO.java
@@ -1,24 +1,34 @@
 package com.mediko.mediko_server.domain.openai.dto.response;
 
 import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
+import com.mediko.mediko_server.domain.openai.domain.SubBodyPart;
+import com.mediko.mediko_server.domain.openai.domain.repository.SubBodyPartRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 public class SelectedSBPResponseDTO {
 
-    private List<String> body;
+    private List<String> description;
 
     private Long selectedSBPId;
 
     private Long selectedMBPId;
 
-    public static SelectedSBPResponseDTO fromEntity(SelectedSBP selectedSBP) {
+    public static SelectedSBPResponseDTO fromEntity(
+            SelectedSBP selectedSBP, SubBodyPartRepository subBodyPartRepository) {
+        List<SubBodyPart> subBodyParts = subBodyPartRepository.findAllById(selectedSBP.getSbpIds());
+
+        List<String> description = subBodyParts.stream()
+                .map(SubBodyPart::getDescription)
+                .collect(Collectors.toList());
+
         return new SelectedSBPResponseDTO(
-                selectedSBP.getBody(),
+                description,
                 selectedSBP.getId(),
                 selectedSBP.getSelectedMBP().getId()
         );

--- a/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSignResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/dto/response/SelectedSignResponseDTO.java
@@ -1,29 +1,38 @@
 package com.mediko.mediko_server.domain.openai.dto.response;
 
 
+import com.mediko.mediko_server.domain.openai.domain.DetailedSign;
 import com.mediko.mediko_server.domain.openai.domain.SelectedSign;
-import com.mediko.mediko_server.domain.openai.domain.SelectedSBP;
+import com.mediko.mediko_server.domain.openai.domain.repository.DetailedSignRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 public class SelectedSignResponseDTO {
 
-    private List<String> sign;
+    private List<String> description;
 
     private Long signId;
 
     private Long selectedSBPId;
 
-    public static SelectedSignResponseDTO fromEntity(SelectedSign selectedSign) {
+    public static SelectedSignResponseDTO fromEntity(
+            SelectedSign selectedSign, DetailedSignRepository detailedSignRepository) {
+        List<DetailedSign> detailedSign = detailedSignRepository.findAllById(selectedSign.getSignIds());
+
+        List<String> description = detailedSign.stream()
+                .map(DetailedSign::getDescription)
+                .collect(Collectors.toList());
+
         return new SelectedSignResponseDTO(
-                selectedSign.getSign(),
+                description,
                 selectedSign.getId(),
                 selectedSign.getSelectedSBP().getId()
         );
     }
-
 }
+

--- a/src/main/java/com/mediko/mediko_server/domain/report/application/ReportMapper.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/application/ReportMapper.java
@@ -1,0 +1,97 @@
+package com.mediko.mediko_server.domain.report.application;
+
+import com.mediko.mediko_server.domain.member.domain.BasicInfo;
+import com.mediko.mediko_server.domain.member.domain.HealthInfo;
+import com.mediko.mediko_server.domain.openai.domain.Symptom;
+import com.mediko.mediko_server.domain.report.domain.Report;
+import com.mediko.mediko_server.domain.report.dto.response.ReportResponseDTO;
+import com.mediko.mediko_server.global.s3.UuidFile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ReportMapper {
+
+    public ReportResponseDTO toDTO(Report report) {
+        return ReportResponseDTO.fromEntity(
+                report,
+                convertToBasicInfoMap(report.getMember().getBasicInfo()),
+                convertToHealthInfoMap(report.getMember().getHealthInfo()),
+                convertToBodyInfoMap(report.getSymptoms()),
+                convertToSymptomInfoMap(report.getSymptoms()),
+                convertToFileInfoMap(report.getSymptoms())
+        );
+    }
+
+    private List<Map<String, Object>> convertToBasicInfoMap(BasicInfo basicInfo) {
+        List<Map<String, Object>> basicInfoList = new ArrayList<>();
+        basicInfoList.add(Map.of(
+                "gender", basicInfo.getGender(),
+                "age", basicInfo.getAge(),
+                "height", basicInfo.getHeight(),
+                "weight", basicInfo.getWeight()
+        ));
+        return basicInfoList;
+    }
+
+    private List<Map<String, String>> convertToHealthInfoMap(HealthInfo healthInfo) {
+        List<Map<String, String>> healthInfoList = new ArrayList<>();
+        healthInfoList.add(Map.of(
+                "past_history", healthInfo.getPastHistory(),
+                "family_history", healthInfo.getFamilyHistory(),
+                "now_medicine", healthInfo.getNowMedicine(),
+                "allergy", healthInfo.getAllergy()
+        ));
+        return healthInfoList;
+    }
+
+    private List<Map<String, Object>> convertToBodyInfoMap(Symptom symptom) {
+        List<Map<String, Object>> bodyInfoList = new ArrayList<>();
+
+        Map<String, Object> bodyInfo = new HashMap<>();
+        bodyInfo.put("mbp_body", symptom.getSelectedMBPBodyParts());
+        bodyInfo.put("sbp_body", symptom.getSelectedSBPBodyParts());
+        bodyInfo.put("sign", symptom.getSelectedSigns());
+
+        bodyInfoList.add(bodyInfo);
+
+        return bodyInfoList;
+    }
+
+    private List<Map<String, String>> convertToSymptomInfoMap(Symptom symptom) {
+        List<Map<String, String>> symptomInfoList = new ArrayList<>();
+
+        if (symptom != null) {
+            symptomInfoList.add(Map.of(
+                    "start_value", String.valueOf(symptom.getStartValue()),
+                    "start_unit", symptom.getStartUnit().toString(),
+                    "duration_value", String.valueOf(symptom.getDurationValue()),
+                    "duration_unit", symptom.getDurationUnit().toString(),
+                    "intensity", String.valueOf(symptom.getIntensity()),
+                    "additional", symptom.getAdditional() != null ? symptom.getAdditional() : ""
+            ));
+        }
+
+        return symptomInfoList;
+    }
+
+    private List<Map<String, String>> convertToFileInfoMap(Symptom symptom) {
+        List<Map<String, String>> fileInfoList = new ArrayList<>();
+
+        if (symptom != null && symptom.getUuidFiles() != null && !symptom.getUuidFiles().isEmpty()) {
+            for (UuidFile uuidFile : symptom.getUuidFiles()) {
+                fileInfoList.add(Map.of(
+                        "imgUrl", uuidFile.getFileUrl()
+                ));
+            }
+        }
+
+        return fileInfoList;
+    }
+}

--- a/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/mediko/mediko_server/domain/report/dto/response/ReportResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/dto/response/ReportResponseDTO.java
@@ -1,7 +1,7 @@
 package com.mediko.mediko_server.domain.report.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mediko.mediko_server.domain.openai.domain.Symptom;
+import com.mediko.mediko_server.domain.report.domain.Report;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,4 +26,39 @@ public class ReportResponseDTO {
     @JsonProperty("symptom_checklist")
     private List<Map<String, Object>> symptomChecklist;
 
+    @JsonProperty("basic_info")
+    private List<Map<String, Object>> basicInfo;
+
+    @JsonProperty("health_info")
+    private List<Map<String, String>> healthInfo;
+
+    @JsonProperty("body_info")
+    private List<Map<String, Object>> bodyInfo;
+
+    @JsonProperty("symptom_info")
+    private List<Map<String, String>> symptomInfo;
+
+    @JsonProperty("image_info")
+    private List<Map<String, String>> fileInfo;
+
+
+    public static ReportResponseDTO fromEntity(
+            Report report,
+            List<Map<String, Object>> basicInfo,
+            List<Map<String, String>> healthInfo,
+            List<Map<String, Object>> bodyInfo,
+            List<Map<String, String>> symptomInfo,
+            List<Map<String, String>> imgInfo) {
+        return new ReportResponseDTO(
+                report.getRecommendedDepartment(),
+                report.getPossibleConditions(),
+                report.getQuestionsForDoctor(),
+                report.getSymptomChecklist(),
+                basicInfo,
+                healthInfo,
+                bodyInfo,
+                symptomInfo,
+                imgInfo
+        );
+    }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- report에 사용자의 기본정보, 건강점보, 문진을 위해 선택한 데이터를 포함해서 reponse하도록 변경
- 주요 신체, 세부 신체, 상세 증상을 저장할 때 response를 영어에서 한국어로 변경
- 상세 증상 저장 시 중복된 sign값이 존재해서 저장 시 오류
   -> 해당 세부 신체에 포함된 값으로 저장되도록 수정 

