### PR TITLE
refactor: AI 문진 요청/응답 구조 변경

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/MemberController.java
@@ -28,9 +28,8 @@ public class MemberController {
 
     @Operation(summary = "회원 가입", description = "신규 회원을 등록합니다.")
     @PostMapping("/sign-up")
-    public ResponseEntity<Void> signUp(
-            @RequestBody SignUpRequestDTO signUpRequestDTO
-    ) {
+    public ResponseEntity<Void> signUp (
+            @RequestBody SignUpRequestDTO signUpRequestDTO) {
         memberService.signUp(signUpRequestDTO);
         return ResponseEntity.status(CREATED).build();
     }
@@ -38,8 +37,7 @@ public class MemberController {
     @Operation(summary = "로그인", description = "등록된 회원을 로그인시킵니다.")
     @PostMapping("/sign-in")
     public ResponseEntity<TokenDTO> signIn(
-            @RequestBody SignInRequestDTO signInRequestDTO
-    ) {
+            @RequestBody SignInRequestDTO signInRequestDTO) {
         TokenDTO tokenDTO = memberService.signIn(signInRequestDTO.getLoginId(), signInRequestDTO.getPassword());
         return ResponseEntity.ok(tokenDTO);
     }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DetailedSignController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/DetailedSignController.java
@@ -30,7 +30,7 @@ public class DetailedSignController {
     @Operation(summary = "상세 중상 부분 조회", description = "선택된 세부 신체에 포함된 모든 상세 증상을 조회합니다.")
     @GetMapping
     public List<DetailedSignResponseDTO> getDetailedSignsBySubBodyPart(
-            @RequestParam(name = "body") String body) {
+            @RequestParam("body") String body) {
         return detailedSignService.getDetailedSignsByBodyPart(body);
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSignController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SelectedSignController.java
@@ -25,8 +25,7 @@ public class SelectedSignController {
     public ResponseEntity<SelectedSignResponseDTO> saveSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,
             @RequestBody SelectedSignRequestDTO requestDTO,
-            @PathVariable(name = "selectedSBPId") Long selectedSBPId)
-    {
+            @PathVariable(name = "selectedSBPId") Long selectedSBPId) {
         Member member = userDetail.getMember();
         SelectedSignResponseDTO responseDTO = selectedSignService.saveSelectedSign(
                 member, requestDTO, selectedSBPId);
@@ -38,8 +37,7 @@ public class SelectedSignController {
     @GetMapping("/{selectedSignId}")
     public ResponseEntity<SelectedSignResponseDTO> getSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,
-            @PathVariable(name = "selectedSignId") Long selectedSignId)
-    {
+            @PathVariable(name = "selectedSignId") Long selectedSignId) {
         Member member = userDetail.getMember();
         SelectedSignResponseDTO responseDTO = selectedSignService.getSelectedSign(selectedSignId, member);
 
@@ -51,8 +49,7 @@ public class SelectedSignController {
     public ResponseEntity<SelectedSignResponseDTO> updateSelectedSign(
             @AuthenticationPrincipal CustomUserDetails userDetail,
             @RequestBody SelectedSignRequestDTO requestDTO,
-            @PathVariable(name = "selectedSignId") Long selectedSignId)
-    {
+            @PathVariable(name = "selectedSignId") Long selectedSignId) {
         Member member = userDetail.getMember();
         SelectedSignResponseDTO responseDTO = selectedSignService.updateSelectedSign(
                 requestDTO, selectedSignId, member);

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SubBodyPartController.java
@@ -32,8 +32,7 @@ public class SubBodyPartController {
     @Operation(summary = "세부 신체 부분 조회", description = "선택된 주요 신체에 포함된 모든 세부 신체를 조회합니다.")
     @GetMapping
     public ResponseEntity<List<SubBodyPartResponseDTO>> getSubBodyPartsByBodies(
-            @RequestParam(name = "body") List<String> body
-    ) {
+            @RequestParam("body") List<String> body) {
         List<SubBodyPart> subBodyParts = subBodyPartService.getSubBodyPartsByMainBodyPartBodies(body);
         List<SubBodyPartResponseDTO> response = subBodyParts.stream()
                 .map(SubBodyPartResponseDTO::fromEntity)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SymptomController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/presentation/SymptomController.java
@@ -41,8 +41,7 @@ public class SymptomController {
     public ResponseEntity<PainStartResponseDTO> savePainStart(
             @PathVariable("selectedSBPIds") String selectedSBPIds,
             @RequestBody PainStartRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
 
         List<Long> idList = Arrays.stream(selectedSBPIds.split(","))
@@ -57,8 +56,7 @@ public class SymptomController {
     @GetMapping("/start/{symptomId}")
     public ResponseEntity<PainStartResponseDTO> getPainStart(
             @PathVariable("symptomId") Long symptomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         PainStartResponseDTO response = symptomService.getPainStart(symptomId, member);
         return ResponseEntity.ok(response);
@@ -69,8 +67,7 @@ public class SymptomController {
     public ResponseEntity<PainStartResponseDTO> updatePainStart(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody PainStartRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         PainStartResponseDTO response = symptomService.updatePainStart(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -85,8 +82,7 @@ public class SymptomController {
     public ResponseEntity<IntensityResponseDTO> saveIntensity(
             @PathVariable("symptomId") Long symptomId,
             @Valid @RequestBody IntensityRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         IntensityResponseDTO response = symptomService.saveIntensity(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -97,8 +93,7 @@ public class SymptomController {
     @GetMapping("/intensity/{symptomId}")
     public ResponseEntity<IntensityResponseDTO> getIntensity(
             @PathVariable("symptomId") Long symptomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         IntensityResponseDTO response = symptomService.getIntensity(symptomId, member);
         return ResponseEntity.ok(response);
@@ -109,8 +104,7 @@ public class SymptomController {
     public ResponseEntity<IntensityResponseDTO> updateIntensity(
             @PathVariable("symptomId") Long symptomId,
             @Valid @RequestBody IntensityRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         IntensityResponseDTO response = symptomService.updateIntensity(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -124,8 +118,7 @@ public class SymptomController {
     public ResponseEntity<DurationResponseDTO> saveDuration(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody DurationRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         DurationResponseDTO response = symptomService.saveDuration(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -135,8 +128,7 @@ public class SymptomController {
     @GetMapping("/duration/{symptomId}")
     public ResponseEntity<DurationResponseDTO> getDuration(
             @PathVariable("symptomId") Long symptomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         DurationResponseDTO response = symptomService.getDuration(symptomId, member);
         return ResponseEntity.ok(response);
@@ -147,8 +139,7 @@ public class SymptomController {
     public ResponseEntity<DurationResponseDTO> updateDuration(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody DurationRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         DurationResponseDTO response = symptomService.updateDuration(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -163,8 +154,7 @@ public class SymptomController {
     public ResponseEntity<AdditionalInfoResponseDTO> saveAdditionalInfo(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody AdditionalInfoRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         AdditionalInfoResponseDTO response = symptomService.saveAdditionalInfo(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);
@@ -174,8 +164,7 @@ public class SymptomController {
     @GetMapping("/additional/{symptomId}")
     public ResponseEntity<AdditionalInfoResponseDTO> getAdditionalInfo(
             @PathVariable("symptomId") Long symptomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         AdditionalInfoResponseDTO response = symptomService.getAdditionalInfo(symptomId, member);
         return ResponseEntity.ok(response);
@@ -186,8 +175,7 @@ public class SymptomController {
     public ResponseEntity<AdditionalInfoResponseDTO> updateAdditionalInfo(
             @PathVariable("symptomId") Long symptomId,
             @RequestBody AdditionalInfoRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         AdditionalInfoResponseDTO response = symptomService.updateAdditionalInfo(symptomId, requestDTO, member);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/domain/Report.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @Entity
 @Table(name= "report")
 public class Report extends BaseEntity {
+
     @Convert(converter = SingleObjectMapConverter.class)
     @Column(name = "department")
     private Map<String, Object> recommendedDepartment;
@@ -41,10 +42,6 @@ public class Report extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "symptom_id", nullable = false)
     private Symptom symptoms;
-
-    @ManyToOne
-    @JoinColumn(name = "basic_info_id", nullable = false)
-    private BasicInfo basicInfo;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/mediko/mediko_server/domain/report/domain/repository/ReportRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/domain/repository/ReportRepository.java
@@ -1,7 +1,18 @@
 package com.mediko.mediko_server.domain.report.domain.repository;
 
+import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.report.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    Optional<Report> findByIdAndMember(Long id, Member member);
+
+    @Query("SELECT r FROM Report r WHERE r.member = :member ORDER BY r.created_at DESC")
+    List<Report> findAllByMemberOrderByCreatedAtDesc(@Param("member") Member member);
 }

--- a/src/main/java/com/mediko/mediko_server/domain/report/dto/request/ReportRequestDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/dto/request/ReportRequestDTO.java
@@ -7,7 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReportRequestDTO {
 
-    private Long basicInfoId;
-
     private Long symptomId;
 }

--- a/src/main/java/com/mediko/mediko_server/domain/report/dto/response/ReportResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/dto/response/ReportResponseDTO.java
@@ -14,6 +14,9 @@ import java.util.Map;
 @NoArgsConstructor
 public class ReportResponseDTO {
 
+    @JsonProperty("report_id")
+    private Long reportId;
+
     @JsonProperty("department")
     private Map<String, Object> recommendedDepartment;
 
@@ -43,13 +46,11 @@ public class ReportResponseDTO {
 
 
     public static ReportResponseDTO fromEntity(
-            Report report,
-            List<Map<String, Object>> basicInfo,
-            List<Map<String, String>> healthInfo,
-            List<Map<String, Object>> bodyInfo,
-            List<Map<String, String>> symptomInfo,
-            List<Map<String, String>> imgInfo) {
+            Report report, List<Map<String, Object>> basicInfo,
+            List<Map<String, String>> healthInfo, List<Map<String, Object>> bodyInfo,
+            List<Map<String, String>> symptomInfo, List<Map<String, String>> imgInfo) {
         return new ReportResponseDTO(
+                report.getId(),
                 report.getRecommendedDepartment(),
                 report.getPossibleConditions(),
                 report.getQuestionsForDoctor(),

--- a/src/main/java/com/mediko/mediko_server/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/report/presentation/ReportController.java
@@ -1,17 +1,22 @@
 package com.mediko.mediko_server.domain.report.presentation;
 
+import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
+import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.report.application.ReportService;
 import com.mediko.mediko_server.domain.report.dto.request.ReportRequestDTO;
 import com.mediko.mediko_server.domain.report.dto.response.ReportResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Tag(name = "report", description = "AI 문진 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -19,10 +24,38 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReportController {
     private final ReportService reportService;
 
+    @Operation(summary = "문진 생성", description = "AI로 응답받은 문진을 저장합니다.")
     @PostMapping
     public ResponseEntity<ReportResponseDTO> generateReport(
-            @RequestBody ReportRequestDTO reportRequestDTO) {
-        ReportResponseDTO response = reportService.generateReport(reportRequestDTO);
+            @RequestBody ReportRequestDTO reportRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetail) {
+
+        Member member = userDetail.getMember();
+        ReportResponseDTO response = reportService.generateReport(reportRequestDTO, member);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "문진 조회", description = "특정 문진을 조회합니다.")
+    @GetMapping("/{reportId}")
+    public ResponseEntity<ReportResponseDTO> getReport(
+            @PathVariable("reportId") Long reportId,
+            @AuthenticationPrincipal CustomUserDetails userDetail) {
+
+        Member member = userDetail.getMember();
+        ReportResponseDTO response = reportService.getReport(reportId, member);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "문진 리스트 조회", description = "회원의 모든 문진들을 조회합니다.")
+    @GetMapping("/all")
+    public ResponseEntity<List<ReportResponseDTO>> getAllReports(
+            @AuthenticationPrincipal CustomUserDetails userDetail) {
+
+        Member member = userDetail.getMember();
+        List<ReportResponseDTO> response = reportService.getAllReportsByMember(member);
+
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #37 

### 🔑 주요 변경사항
- selectedMBP/SBP/Sgin의 request에서 body/sign 값을 넣으면 response의 description으로 출력되도록 변경
- report의 request에서 basicInfo를 제거하고 member를 자동 주입받는 방식으로 변경
- report 조회, 회원 별 전체 조회 api 추가

