### PR TITLE
refactor: 언어/기본정보/건강정보 생성은 memberId를 파라미터로 받아서 사용

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedEr.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/domain/SelectedEr.java
@@ -2,7 +2,6 @@ package com.mediko.mediko_server.domain.map.domain;
 
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.recommend.domain.Er;
-import com.mediko.mediko_server.domain.recommend.domain.Hospital;
 import com.mediko.mediko_server.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedErController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedErController.java
@@ -21,7 +21,7 @@ public class SelectedErController {
     @Operation(summary = "응급실 선택 및 map url", description = "사용자가 선택한 응급실을 저장하고 map url을 반환합니다.")
     @GetMapping("/{erId}")
     public ResponseEntity<ErWithMapUrlDTO> getErWithMapUrls(
-            @PathVariable Long erId,
+            @PathVariable("erId") Long erId,
             @AuthenticationPrincipal Member member) {
         ErWithMapUrlDTO response = selectedErService.getErWithMapUrls(erId, member);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedHospitalController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedHospitalController.java
@@ -20,7 +20,7 @@ public class SelectedHospitalController {
     @Operation(summary = "병원 선택 및 map url", description = "사용자가 선택한 병원을 저장하고 map url을 반환합니다.")
     @GetMapping("/{hospitalId}")
     public ResponseEntity<HospitalWithMapUrlDTO> getHospitalWithMapUrls(
-            @PathVariable Long hospitalId,
+            @PathVariable("hospitalId") Long hospitalId,
             @AuthenticationPrincipal Member member) {
         HospitalWithMapUrlDTO response = selectedHospitalService.getHospitalWithMapUrls(hospitalId, member);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedPharmacyController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/map/presentation/SelectedPharmacyController.java
@@ -20,7 +20,7 @@ public class SelectedPharmacyController {
     @Operation(summary = "약국 선택 및 map url", description = "사용자가 선택한 약국을 저장하고 map url을 반환합니다.")
     @GetMapping("/{pharmacyId}")
     public ResponseEntity<PharmacyWithMapUrlDTO> getPharmacyWithMapUrls(
-            @PathVariable Long pharmacyId,
+            @PathVariable("pharmacyId") Long pharmacyId,
             @AuthenticationPrincipal Member member) {
         PharmacyWithMapUrlDTO response = selectedPharmacyService.getPharmacyWithMapUrls(pharmacyId, member);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/BasicInfoService.java
@@ -4,6 +4,7 @@ import com.mediko.mediko_server.domain.member.domain.BasicInfo;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.member.domain.infoType.UserStatus;
 import com.mediko.mediko_server.domain.member.domain.repository.BasicInfoRepository;
+import com.mediko.mediko_server.domain.member.domain.repository.MemberRepository;
 import com.mediko.mediko_server.domain.member.dto.request.BasicInfoRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.request.LanguageRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.response.BasicInfoResponseDTO;
@@ -11,6 +12,7 @@ import com.mediko.mediko_server.domain.member.dto.response.ErPasswordResponseDTO
 import com.mediko.mediko_server.domain.member.dto.response.LanguageResponseDTO;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
 import com.mediko.mediko_server.global.flask.application.FlaskCommunicationService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,12 +26,16 @@ import static com.mediko.mediko_server.global.exception.ErrorCode.*;
 @Transactional(readOnly = true)
 public class BasicInfoService {
 
+    private final MemberRepository memberRepository;
     private final BasicInfoRepository basicInfoRepository;
     private final FlaskCommunicationService flaskCommunicationService;
 
     // 사용자 언어 설정
     @Transactional
-    public LanguageResponseDTO setLanguage(Member member, LanguageRequestDTO languageRequestDTO) {
+    public LanguageResponseDTO setLanguage(Long memberId, LanguageRequestDTO languageRequestDTO) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
+
         BasicInfo basicInfo = basicInfoRepository.findByMember(member)
                 .orElseGet(() -> {
                     String erPassword = flaskCommunicationService.generate119Password();
@@ -50,7 +56,10 @@ public class BasicInfoService {
 
     // 사용자 기본정보 생성
     @Transactional
-    public BasicInfoResponseDTO saveBasicInfo(Member member, BasicInfoRequestDTO requestDTO) {
+    public BasicInfoResponseDTO saveBasicInfo(Long memberId, BasicInfoRequestDTO requestDTO) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
+
         BasicInfo basicInfo = basicInfoRepository.findByMember(member)
                 .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "먼저 language 설정이 필요합니다."));
 

--- a/src/main/java/com/mediko/mediko_server/domain/member/application/HealthInfoService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/HealthInfoService.java
@@ -3,6 +3,7 @@ package com.mediko.mediko_server.domain.member.application;
 import com.mediko.mediko_server.domain.member.domain.HealthInfo;
 import com.mediko.mediko_server.domain.member.domain.Member;
 import com.mediko.mediko_server.domain.member.domain.repository.HealthInfoRepository;
+import com.mediko.mediko_server.domain.member.domain.repository.MemberRepository;
 import com.mediko.mediko_server.domain.member.dto.request.HealthInfoRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.response.HealthInfoResponseDTO;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
@@ -20,11 +21,15 @@ import static com.mediko.mediko_server.global.exception.ErrorCode.DATA_NOT_EXIST
 @Transactional(readOnly = true)
 public class HealthInfoService {
 
+    private final MemberRepository memberRepository;
     private final HealthInfoRepository healthInfoRepository;
 
     //사용자 건강정보 저장
     @Transactional
-    public HealthInfoResponseDTO createHealthInfo(Member member, HealthInfoRequestDTO healthInfoRequestDTO) {
+    public HealthInfoResponseDTO saveHealthInfo(Long memberId, HealthInfoRequestDTO healthInfoRequestDTO) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(DATA_NOT_EXIST, "존재하지 않는 사용자입니다."));
+
         if (healthInfoRepository.existsByMember(member)) {
             throw new BadRequestException(DATA_ALREADY_EXIST, "사용자의 건강정보가 이미 저장되었습니다.");
         }

--- a/src/main/java/com/mediko/mediko_server/domain/member/application/MemberService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/application/MemberService.java
@@ -5,12 +5,15 @@ import com.mediko.mediko_server.domain.member.domain.infoType.UserStatus;
 import com.mediko.mediko_server.domain.member.domain.repository.MemberRepository;
 import com.mediko.mediko_server.domain.member.dto.request.SignUpRequestDTO;
 import com.mediko.mediko_server.domain.member.dto.request.TokenDTO;
+import com.mediko.mediko_server.domain.member.dto.response.UserInfoResponseDTO;
 import com.mediko.mediko_server.global.exception.exceptionType.BadRequestException;
 import com.mediko.mediko_server.global.security.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -21,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.mediko.mediko_server.global.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.CREATED;
 
 @Slf4j
 @Service
@@ -34,7 +38,7 @@ public class MemberService {
 
     //회원 가입
     @Transactional
-    public void signUp(SignUpRequestDTO signUpRequestDTO) {
+    public UserInfoResponseDTO signUp(SignUpRequestDTO signUpRequestDTO) {
         if (memberRepository.existsByEmail(signUpRequestDTO.getEmail())) {
             throw new BadRequestException(DATA_ALREADY_EXIST, "이미 사용 중인 이메일입니다.");
         }
@@ -52,9 +56,10 @@ public class MemberService {
 
         Member member = signUpRequestDTO.toEntity(encodedPassword);
         member.addRole(UserStatus.ROLE_GUEST);
-        memberRepository.save(member);
-    }
+        Member savedMember = memberRepository.save(member);
 
+        return UserInfoResponseDTO.fromEntity(savedMember);
+    }
 
     //로그인
     @Transactional

--- a/src/main/java/com/mediko/mediko_server/domain/member/dto/response/HealthInfoResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/dto/response/HealthInfoResponseDTO.java
@@ -1,7 +1,6 @@
 package com.mediko.mediko_server.domain.member.dto.response;
 
 import com.mediko.mediko_server.domain.member.domain.HealthInfo;
-import com.mediko.mediko_server.domain.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/mediko/mediko_server/domain/member/dto/response/UserInfoResponseDTO.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/dto/response/UserInfoResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserInfoResponseDTO {
+    private Long memberId;
 
     private String loginId;
 
@@ -19,6 +20,7 @@ public class UserInfoResponseDTO {
 
     public static UserInfoResponseDTO fromEntity(Member member) {
         return new UserInfoResponseDTO(
+                member.getId(),
                 member.getLoginId(),
                 member.getEmail(),
                 member.getName(),

--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/BasicInfoController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/BasicInfoController.java
@@ -31,11 +31,10 @@ public class BasicInfoController {
     @Operation(summary = "사용자 언어 설정", description = "사용자의 언어를 설정합니다.")
     @PostMapping("/language")
     public ResponseEntity<LanguageResponseDTO> setLanguage(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("memberId") Long memberId,
             @RequestBody LanguageRequestDTO languageRequestDTO) {
 
-        Member member = userDetails.getMember();
-        LanguageResponseDTO responseDTO = basicInfoService.setLanguage(member, languageRequestDTO);
+        LanguageResponseDTO responseDTO = basicInfoService.setLanguage(memberId, languageRequestDTO);
 
         return ResponseEntity.ok(responseDTO);
     }
@@ -43,12 +42,11 @@ public class BasicInfoController {
     @Operation(summary = "사용자 기본 정보 생성", description = "사용자의 기본 정보를 최초 생성합니다.")
     @PostMapping
     public ResponseEntity<BasicInfoResponseDTO> saveBasicInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("memberId") Long memberId,
             @RequestBody BasicInfoRequestDTO requestDTO) {
-        Member member = userDetails.getMember();
         return ResponseEntity
                 .status(CREATED)
-                .body(basicInfoService.saveBasicInfo(member, requestDTO));
+                .body(basicInfoService.saveBasicInfo(memberId, requestDTO));
     }
 
     @Operation(summary = "사용자 기본 정보 수정", description = "저장된 사용자의 기본 정보를 부분 수정합니다.")

--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/HealthInfoController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/HealthInfoController.java
@@ -28,10 +28,9 @@ public class HealthInfoController {
     @Operation(summary = "사용자 건강 정보 저장", description = "회원가입 후 사용자의 건강 정보를 저장합니다.")
     @PostMapping
     public ResponseEntity<HealthInfoResponseDTO> saveHealthInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("memberId") Long memberId,
             @RequestBody HealthInfoRequestDTO healthInfoRequestDTO) {
-        Member member = userDetails.getMember();
-        HealthInfoResponseDTO savedHealthInfo = healthInfoService.createHealthInfo(member, healthInfoRequestDTO);
+        HealthInfoResponseDTO savedHealthInfo = healthInfoService.saveHealthInfo(memberId, healthInfoRequestDTO);
         return ResponseEntity.status(CREATED).body(savedHealthInfo);
     }
 

--- a/src/main/java/com/mediko/mediko_server/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/mediko/mediko_server/domain/member/presentation/MemberController.java
@@ -3,10 +3,12 @@ package com.mediko.mediko_server.domain.member.presentation;
 import com.mediko.mediko_server.domain.member.application.CustomUserDetails;
 import com.mediko.mediko_server.domain.member.application.MemberService;
 import com.mediko.mediko_server.domain.member.dto.request.*;
+import com.mediko.mediko_server.domain.member.dto.response.UserInfoResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,16 +30,14 @@ public class MemberController {
 
     @Operation(summary = "회원 가입", description = "신규 회원을 등록합니다.")
     @PostMapping("/sign-up")
-    public ResponseEntity<Void> signUp (
-            @RequestBody SignUpRequestDTO signUpRequestDTO) {
-        memberService.signUp(signUpRequestDTO);
-        return ResponseEntity.status(CREATED).build();
+    public ResponseEntity<UserInfoResponseDTO> signUp(@RequestBody SignUpRequestDTO signUpRequestDTO) {
+        UserInfoResponseDTO responseDTO = memberService.signUp(signUpRequestDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
     }
 
     @Operation(summary = "로그인", description = "등록된 회원을 로그인시킵니다.")
     @PostMapping("/sign-in")
-    public ResponseEntity<TokenDTO> signIn(
-            @RequestBody SignInRequestDTO signInRequestDTO) {
+    public ResponseEntity<TokenDTO> signIn(@RequestBody SignInRequestDTO signInRequestDTO) {
         TokenDTO tokenDTO = memberService.signIn(signInRequestDTO.getLoginId(), signInRequestDTO.getPassword());
         return ResponseEntity.ok(tokenDTO);
     }

--- a/src/main/java/com/mediko/mediko_server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/mediko/mediko_server/global/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.mediko.mediko_server.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,16 +36,16 @@ public class SecurityConfig {
                 .csrf(csrfConfigurer -> csrfConfigurer.disable())
                 .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequestsConfigurer -> authorizeRequestsConfigurer
-                        // Swagger 관련 경로 허용
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html"
                         ).permitAll()
-                        // 회원가입 및 로그인 API 허용
                         .requestMatchers("/api/v1/member/sign-up").permitAll()
                         .requestMatchers("/api/v1/member/sign-in").permitAll()
-                        // 그 외 모든 요청 인증 필요
+                        .requestMatchers("/api/v1/basicInfo/language").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/basicInfo").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/healthInfo").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- 회원가입 후 로그인을 하기 전에 사용자의 언어 선택,  기본정보 생성, 건강정보 생성이 이루어져야 하므로 해당 기능은 @AuthenticationPrincipal을 사용하지 않고 memberId를 파라미터로 입력받아서 생성하는 방식으로 변경

