### PR TITLE
fix: Translation 조회 시 중복 데이터로 인한 NonUniqueResultException 해결

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/DetailedSignService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/DetailedSignService.java
@@ -40,7 +40,6 @@ public class DetailedSignService {
     public List<DetailedSignResponseDTO> getDetailedSignsByBodyPart(String description, Member member) {
         Language language = member.getBasicInfo().getLanguage();
 
-        // 번역된 body값을 한국어로 변환
         String koreanDescription = translationService.getTextKo(description, TranslationType.SUB_BODY_PART, language);
 
         subBodyPartRepository.findByDescription(koreanDescription)

--- a/src/main/java/com/mediko/mediko_server/domain/openai/domain/DetailedSign.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/domain/DetailedSign.java
@@ -27,7 +27,12 @@ public class DetailedSign extends BaseEntity  {
     @JoinColumn(name = "sbp_id")
     private SubBodyPart subBodyPart;
 
-    public String getTranslatedDescription(Language language, TranslationService translationService) {
-        return translationService.translate(description, TranslationType.DETAILED_SIGN, language);
+    public String getTranslatedDescription(
+            Language language, TranslationService translationService) {
+        return translationService.translate(
+                this.description,
+                TranslationType.DETAILED_SIGN,
+                language
+        );
     }
 }

--- a/src/main/java/com/mediko/mediko_server/domain/translation/application/TranslationService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/translation/application/TranslationService.java
@@ -23,7 +23,14 @@ public class TranslationService {
     public String translate(String textKo, TranslationType type, Language language) {
         if (textKo == null) return null;
 
-        return translationRepository.findByTextKoAndType(textKo, type)
+        List<Translation> translations = translationRepository.findByTextKoAndType(textKo, type);
+        if (translations.isEmpty()) {
+            return textKo;
+        }
+
+        return translations.stream()
+                .filter(translation -> translation.getTextKo().equals(textKo))
+                .findFirst()
                 .map(translation -> translation.getTranslatedText(language))
                 .orElse(textKo);
     }
@@ -36,7 +43,8 @@ public class TranslationService {
                 .stream()
                 .collect(Collectors.toMap(
                         Translation::getTextKo,
-                        translation -> translation
+                        translation -> translation,
+                        (existing, replacement) -> existing // 중복 시 첫 번째 값 유지
                 ));
 
         return textKos.stream()

--- a/src/main/java/com/mediko/mediko_server/domain/translation/domain/repository/TranslationRepository.java
+++ b/src/main/java/com/mediko/mediko_server/domain/translation/domain/repository/TranslationRepository.java
@@ -4,29 +4,27 @@ import com.mediko.mediko_server.domain.member.domain.infoType.Language;
 import com.mediko.mediko_server.domain.translation.domain.Translation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface TranslationRepository extends JpaRepository<Translation, Long> {
-    Optional<Translation> findByTextKoAndType(String textKo, TranslationType type);
+    List<Translation> findByTextKoAndType(String textKo, TranslationType type);
     List<Translation> findByTextKoInAndType(List<String> textKos, TranslationType type);
-
-
 
     default Optional<Translation> findByTranslatedTextAndTypeAndLanguage(String translatedText, TranslationType type, Language language) {
         return switch (language) {
-            case KO -> findByTextKoAndType(translatedText, type);
-            case EN -> findByTextEnAndType(translatedText, type);
-            case VI -> findByTextViAndType(translatedText, type);
-            case ZH_CN -> findByTextZhCnAndType(translatedText, type);
-            case ZH_TW -> findByTextZhTwAndType(translatedText, type);
-            default -> findByTextKoAndType(translatedText, type);
+            case KO -> findFirstByTextKoAndType(translatedText, type);
+            case EN -> findFirstByTextEnAndType(translatedText, type);
+            case VI -> findFirstByTextViAndType(translatedText, type);
+            case ZH_CN -> findFirstByTextZhCnAndType(translatedText, type);
+            case ZH_TW -> findFirstByTextZhTwAndType(translatedText, type);
+            default -> findFirstByTextKoAndType(translatedText, type);
         };
     }
 
-    Optional<Translation> findByTextEnAndType(String textEn, TranslationType type);
-    Optional<Translation> findByTextViAndType(String textVi, TranslationType type);
-    Optional<Translation> findByTextZhCnAndType(String textZhCn, TranslationType type);
-    Optional<Translation> findByTextZhTwAndType(String textZhTw, TranslationType type);
+    Optional<Translation> findFirstByTextKoAndType(String textKo, TranslationType type);
+    Optional<Translation> findFirstByTextEnAndType(String textEn, TranslationType type);
+    Optional<Translation> findFirstByTextViAndType(String textVi, TranslationType type);
+    Optional<Translation> findFirstByTextZhCnAndType(String textZhCn, TranslationType type);
+    Optional<Translation> findFirstByTextZhTwAndType(String textZhTw, TranslationType type);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
-  동일한 텍스트에 대한 번역이 여러 개 존재하여 에러 발생
-  세부신체에 해당하는 증상에 대한 번역만 조회되도록 변경
