### PR TITLE
fix: 상세증상 중복입력 문제 해결

### DIFF
--- a/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSignService.java
+++ b/src/main/java/com/mediko/mediko_server/domain/openai/application/SelectedSignService.java
@@ -54,21 +54,21 @@ public class SelectedSignService {
         try {
             List<DetailedSign> validSigns = new ArrayList<>();
             for (String userInputDesc : descriptions) {
-                boolean found = false;
                 for (DetailedSign sign : selectedDetailedSigns) {
+                    if (!selectedSBP.getSbpIds().contains(sign.getSubBodyPart().getId())) {
+                        continue;
+                    }
+
                     String translatedSign = translationService.translate(
                             sign.getDescription(),
                             TranslationType.DETAILED_SIGN,
                             member.getBasicInfo().getLanguage()
                     );
+
                     if (userInputDesc.equals(translatedSign)) {
                         validSigns.add(sign);
-                        found = true;
                         break;
                     }
-                }
-                if (!found) {
-                    log.warn("매칭되지 않은 증상: {}", userInputDesc);
                 }
             }
 
@@ -81,7 +81,6 @@ public class SelectedSignService {
 
         } catch (Exception e) {
             if (!(e instanceof BadRequestException)) {
-                log.error("증상 처리 중 오류 발생: {}", e.getMessage());
                 throw new BadRequestException(INVALID_PARAMETER,
                         "증상 처리 중 오류가 발생했습니다.");
             }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 관련 이슈
- #73 

### 🔑 주요 변경사항
- 상세증상을 선택 시 선택한 세부신체가 다르지만 이름이 같은 증상인 모든 값들이 중복 선택되는 문제 해결 

